### PR TITLE
tiktok viewer stats now live not cumulative - fixes #12

### DIFF
--- a/Mode-S Client/scripts/sidecar/tiktok_sidecar.py
+++ b/Mode-S Client/scripts/sidecar/tiktok_sidecar.py
@@ -1,23 +1,27 @@
 #!/usr/bin/env python
 # TikTok sidecar for Mode-S Client
-# - "viewers" should match TikTok website "watching now"
-# - On your payload, "user_count" is the correct field
-# - Robust against SignAPIError (temporary signer 500/504)
+# FINAL SIMPLIFIED VERSION
+#
+# Viewers logic:
+#   - viewers == room_info.user_count ONLY
+#   - No totals, no popularity, no heuristics
+#   - Matches TikTok website "watching now"
 
 import asyncio
 import json
 import sys
 import time
 import traceback
+import inspect
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Callable, Tuple
 
 # ---------------- stdout pipe safety (Windows) ----------------
 def emit(obj: Dict[str, Any]) -> None:
     try:
         print(json.dumps(obj, ensure_ascii=False), flush=True)
     except (BrokenPipeError, OSError):
-        # When piped (findstr/PS) and consumer exits, Windows may throw OSError 22/32.
+        # Downstream pipe closed (findstr / PowerShell)
         raise SystemExit(0)
 
 
@@ -25,19 +29,13 @@ def now_ts() -> float:
     return time.time()
 
 
-def log(t: str, msg: str, **extra):
-    payload = {"type": t, "ts": now_ts(), "message": msg}
-    payload.update(extra)
-    emit(payload)
-
-
 def emit_stats(
     live: bool,
     viewers: int,
     note: str = "",
     room_id: Optional[int] = None,
-    **extra
 ):
+    # IMPORTANT: Always emit a fresh stats object so downstream rewrites the value each poll.
     payload = {
         "type": "tiktok.stats",
         "ts": now_ts(),
@@ -47,6 +45,11 @@ def emit_stats(
     }
     if room_id is not None:
         payload["room_id"] = int(room_id)
+    emit(payload)
+
+
+def log(t: str, msg: str, **extra):
+    payload = {"type": t, "ts": now_ts(), "message": msg}
     payload.update(extra)
     emit(payload)
 
@@ -66,106 +69,142 @@ def load_config() -> Dict[str, Any]:
 
 # ---------------- TikTokLive ----------------
 from TikTokLive import TikTokLiveClient
-from TikTokLive.events import ConnectEvent, DisconnectEvent, CommentEvent, RoomUserSeqEvent
+from TikTokLive.events import ConnectEvent, DisconnectEvent, CommentEvent
 
-# Signer error type (optional import depending on package layout)
 try:
     from TikTokLive.client.errors import SignAPIError  # type: ignore
 except Exception:
     SignAPIError = None  # type: ignore
 
+
 emit({"type": "tiktok.boot", "ts": now_ts()})
 
 
-# ---------------- helpers: data mining ----------------
-def _is_int(v: Any) -> bool:
-    return isinstance(v, int) and not isinstance(v, bool)
+# ---------------- helpers ----------------
+def extract_user_count(obj: Any) -> Optional[int]:
+    """
+    Extract ONLY user_count from room info.
+    This matches the TikTok website viewer number on this build.
+    """
+    if obj is None:
+        return None
 
-
-def collect_ints(obj: Any, prefix: str = "", max_depth: int = 6) -> Dict[str, int]:
-    """Recursively collect int fields from dict-like or object-like payloads."""
-    out: Dict[str, int] = {}
-    if obj is None or max_depth <= 0:
-        return out
-
-    if isinstance(obj, dict):
-        for k, v in obj.items():
-            key = f"{prefix}{k}"
-            if _is_int(v):
-                out[key] = int(v)
-            elif isinstance(v, dict):
-                out.update(collect_ints(v, key + ".", max_depth - 1))
-            else:
-                if hasattr(v, "__dict__"):
-                    out.update(collect_ints(v, key + ".", max_depth - 1))
-        return out
-
+    # Direct attribute
     try:
-        d = getattr(obj, "__dict__", None)
-        if isinstance(d, dict):
-            for k, v in d.items():
-                key = f"{prefix}{k}"
-                if _is_int(v):
-                    out[key] = int(v)
-                elif isinstance(v, dict):
-                    out.update(collect_ints(v, key + ".", max_depth - 1))
-                else:
-                    if hasattr(v, "__dict__"):
-                        out.update(collect_ints(v, key + ".", max_depth - 1))
+        v = getattr(obj, "user_count", None)
+        if isinstance(v, int) and v >= 0:
+            return v
     except Exception:
         pass
 
-    return out
+    # Dict
+    if isinstance(obj, dict):
+        v = obj.get("user_count")
+        if isinstance(v, int) and v >= 0:
+            return v
 
+    # Nested common containers
+    for name in ("stats", "data", "room", "room_info", "roomInfo"):
+        try:
+            nested = getattr(obj, name, None)
+            v = extract_user_count(nested)
+            if v is not None:
+                return v
+        except Exception:
+            pass
 
-def pick_viewers_from_roominfo_candidates(candidates: Dict[str, int]) -> Tuple[Optional[str], Optional[int]]:
-    """
-    HARD RULE (per your request):
-      - Prefer 'user_count' (matches TikTok website in your debug dump)
-      - Else prefer 'stats.watch_user_count' if present and > 0
-      - Else try a small safe set of likely concurrent counters
-      - Never use totals/cumulative/popularity
-    """
-    # 1) Exact 'user_count' wins
-    if "user_count" in candidates and candidates["user_count"] >= 0:
-        return "user_count", candidates["user_count"]
-
-    # Sometimes it may appear under a different path (rare); check endswith
-    for k, v in candidates.items():
-        if k.lower().endswith(".user_count") and v >= 0:
-            return k, v
-
-    # 2) Some payloads provide watch_user_count; only if non-zero
-    for k in ("stats.watch_user_count", "watch_user_count", "stats.watchUserCount", "watchUserCount"):
-        if k in candidates and candidates[k] > 0:
-            return k, candidates[k]
-
-    # 3) Safe fallbacks (concurrent-ish). Still avoid totals.
-    safe_keys = [
-        "stats.current_viewers",
-        "stats.viewer_count",
-        "viewer_count",
-        "stats.userCount",
-        "userCount",
-        "stats.online_user",
-        "online_user",
-    ]
-    for k in safe_keys:
-        if k in candidates and candidates[k] >= 0:
-            return k, candidates[k]
-
-    # 4) Nothing suitable
-    return None, None
+    return None
 
 
 def is_signer_failure(exc: BaseException) -> bool:
     msg = str(exc).lower()
     if "sign_not_200" in msg or "sign api" in msg or "504" in msg:
         return True
-    # If SignAPIError class exists, also match it
     if SignAPIError is not None and isinstance(exc, SignAPIError):
         return True
     return False
+
+
+async def call_maybe_async(fn: Callable[..., Any], *args: Any) -> Any:
+    """
+    Call fn with args, supporting both sync and async callables.
+    """
+    res = fn(*args)
+    return await res if asyncio.iscoroutine(res) else res
+
+
+def candidate_fetchers(client: Any) -> Tuple[Tuple[str, Callable[..., Any]], ...]:
+    """
+    Return a list of (label, callable) fetchers that are likely to perform a *fresh* room info fetch.
+    We try public APIs first, then common internal ones used across TikTokLive versions.
+    """
+    cands: list[Tuple[str, Callable[..., Any]]] = []
+
+    # Public-ish names seen across versions
+    for name in ("fetch_room_info", "get_room_info", "room_info", "fetchRoomInfo", "getRoomInfo"):
+        fn = getattr(client, name, None)
+        if callable(fn):
+            cands.append((f"client.{name}", fn))
+
+    # Internal/common objects that sometimes exist
+    for obj_name in ("_web", "web", "_client", "client", "_room", "room"):
+        obj = getattr(client, obj_name, None)
+        if obj is None:
+            continue
+        for name in ("fetch_room_info", "get_room_info", "room_info", "fetchRoomInfo", "getRoomInfo"):
+            fn = getattr(obj, name, None)
+            if callable(fn):
+                cands.append((f"{obj_name}.{name}", fn))
+
+    return tuple(cands)
+
+
+async def fetch_fresh_room_info(client: Any, room_id: Optional[int]) -> Tuple[Optional[Any], str]:
+    """
+    Try hard to fetch a fresh room-info object every poll.
+    Returns (info, label_used). If nothing worked: (None, "none").
+    """
+    for label, fn in candidate_fetchers(client):
+        try:
+            # Some versions require room_id; others accept no args.
+            sig = None
+            try:
+                sig = inspect.signature(fn)
+            except Exception:
+                sig = None
+
+            if sig is not None:
+                # If it looks like it expects at least 1 positional arg (beyond self),
+                # try with room_id first when available.
+                params = list(sig.parameters.values())
+                wants_arg = any(
+                    p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD) and p.default is p.empty
+                    for p in params[1:]  # skip self
+                )
+                if wants_arg and room_id is not None:
+                    info = await call_maybe_async(fn, room_id)
+                else:
+                    info = await call_maybe_async(fn)
+            else:
+                # No signature info; try (room_id) then ().
+                if room_id is not None:
+                    try:
+                        info = await call_maybe_async(fn, room_id)
+                    except TypeError:
+                        info = await call_maybe_async(fn)
+                else:
+                    info = await call_maybe_async(fn)
+
+            if info is not None:
+                return info, label
+        except TypeError:
+            # Wrong arity; keep trying other candidates
+            continue
+        except Exception:
+            # Fetch failed; try next candidate
+            continue
+
+    return None, "none"
 
 
 # ---------------- main ----------------
@@ -184,9 +223,7 @@ async def main_async() -> int:
 
     last_room_id: Optional[int] = None
     last_viewers: int = 0
-
-    dumped_room_user_seq = False
-    dumped_room_info_choice = False
+    dumped_missing_user_count = False
 
     # ---------------- events ----------------
     @client.on(ConnectEvent)
@@ -194,6 +231,7 @@ async def main_async() -> int:
         nonlocal last_room_id
         last_room_id = getattr(event, "room_id", None)
         emit({"type": "tiktok.connected", "ts": now_ts()})
+        # Emit immediately (may be 0 until first poll refreshes)
         emit_stats(True, last_viewers, note="connected", room_id=last_room_id)
 
     @client.on(DisconnectEvent)
@@ -213,85 +251,50 @@ async def main_async() -> int:
         except Exception:
             pass
 
-    @client.on(RoomUserSeqEvent)
-    async def on_room_user_seq(event: RoomUserSeqEvent):
-        # On your build, this event does NOT expose concurrent viewers.
-        # Emit one-shot debug keys and ignore.
-        nonlocal dumped_room_user_seq
-        if not dumped_room_user_seq:
-            dumped_room_user_seq = True
-            try:
-                emit({
-                    "type": "tiktok.debug",
-                    "ts": now_ts(),
-                    "label": "room_user_seq.keys",
-                    "keys": list((event.__dict__ or {}).keys()),
-                })
-            except Exception:
-                pass
-
-    # ---------------- room info polling (source of truth) ----------------
+    # ---------------- room info polling (SOURCE OF TRUTH) ----------------
     async def poll_room_info():
-        nonlocal last_viewers, dumped_room_info_choice
+        nonlocal last_viewers, dumped_missing_user_count
 
         while True:
             await asyncio.sleep(5)
 
-            info = None
+            # Always try to fetch *fresh* room info each poll
+            info, used = await fetch_fresh_room_info(client, last_room_id)
 
-            # Try common async methods
-            for fn_name in ("fetch_room_info", "get_room_info", "room_info"):
-                try:
-                    fn = getattr(client, fn_name, None)
-                    if callable(fn):
-                        maybe = fn()
-                        info = await maybe if asyncio.iscoroutine(maybe) else maybe
-                        if info is not None:
-                            break
-                except Exception:
-                    info = None
-
-            # Some builds stash room info on an attribute
             if info is None:
-                for attr in ("room_info", "roomInfo", "room", "data"):
+                # Do NOT fall back to cached attributes (they can be stale).
+                emit({
+                    "type": "tiktok.warn",
+                    "ts": now_ts(),
+                    "message": "room_info_poll: no fresh room info method available",
+                })
+                # Still emit stats so downstream sees ongoing polls (viewers stays as last known).
+                emit_stats(True, last_viewers, note="room_info_poll_no_fresh_info", room_id=last_room_id)
+                continue
+
+            viewers = extract_user_count(info)
+
+            if viewers is None:
+                if not dumped_missing_user_count:
+                    dumped_missing_user_count = True
                     try:
-                        v = getattr(client, attr, None)
-                        if v is not None:
-                            info = v
-                            break
+                        emit({
+                            "type": "tiktok.debug",
+                            "ts": now_ts(),
+                            "label": "user_count_missing",
+                            "fetcher": used,
+                            "keys": list((getattr(info, "__dict__", {}) or {}).keys()),
+                        })
                     except Exception:
                         pass
-
-            if info is None:
-                emit({"type": "tiktok.warn", "ts": now_ts(), "message": "room_info_poll: no room info available"})
+                # Still emit stats each poll (keep last_viewers) so field is rewritten.
+                emit_stats(True, last_viewers, note=f"room_info_poll_missing_user_count:{used}", room_id=last_room_id)
                 continue
 
-            candidates = collect_ints(info)
-            chosen_key, chosen_value = pick_viewers_from_roominfo_candidates(candidates)
+            last_viewers = int(viewers)
 
-            # One-shot debug to confirm fields
-            if not dumped_room_info_choice:
-                dumped_room_info_choice = True
-                try:
-                    top_by_value = dict(sorted(candidates.items(), key=lambda kv: kv[1], reverse=True)[:30])
-                    emit({
-                        "type": "tiktok.debug",
-                        "ts": now_ts(),
-                        "label": "room_info.choice",
-                        "chosen_key": chosen_key,
-                        "chosen_value": chosen_value,
-                        "top_by_value": top_by_value,
-                    })
-                except Exception:
-                    pass
-
-            if chosen_key is None or chosen_value is None:
-                emit({"type": "tiktok.warn", "ts": now_ts(), "message": "room_info_poll: no suitable viewer counter found"})
-                continue
-
-            # Per your request: populate viewers using the website-like field (user_count)
-            last_viewers = int(chosen_value)
-            emit_stats(True, last_viewers, note="room_info_poll", room_id=last_room_id, key=chosen_key)
+            # IMPORTANT: emit every poll, not only when it changes
+            emit_stats(True, last_viewers, note=f"room_info_poll:{used}", room_id=last_room_id)
 
     asyncio.create_task(poll_room_info())
 
@@ -301,21 +304,25 @@ async def main_async() -> int:
         attempt += 1
         try:
             await client.connect(fetch_room_info=True)
-            # If connect returns normally, stop
             emit_stats(False, 0, note="connect_returned", room_id=last_room_id)
             return 0
         except Exception as e:
-            tb = traceback.format_exc()
-
             if is_signer_failure(e):
-                # Retry with backoff (don’t exit)
                 delay = min(2.0 * attempt, 10.0) + 0.5
-                emit({"type": "tiktok.warn", "ts": now_ts(), "message": f"Signer failure (temporary). Retrying in {delay:.1f}s", "details": str(e)})
+                emit({
+                    "type": "tiktok.warn",
+                    "ts": now_ts(),
+                    "message": f"Signer failure (temporary). Retrying in {delay:.1f}s",
+                })
                 await asyncio.sleep(delay)
                 continue
 
-            # Non-signer error: log and exit
-            emit({"type": "tiktok.error", "ts": now_ts(), "message": "Unhandled exception", "details": tb})
+            emit({
+                "type": "tiktok.error",
+                "ts": now_ts(),
+                "message": "Unhandled exception",
+                "details": traceback.format_exc(),
+            })
             return 2
 
 


### PR DESCRIPTION
## Summary

Fix TikTok live viewer count reporting to reliably match the TikTok website’s **“watching now”** figure.

This PR simplifies and hardens the TikTok sidecar logic by removing incorrect cumulative/popularity counters and locking the viewer metric to the correct concurrent field (`user_count`). It also ensures the value is **actively refreshed and re-emitted on every poll**, preventing stale values caused by cached room info or downstream consumers missing updates.

---

## Key Changes

### ✅ Correct Viewer Metric

- Viewer count is now sourced **exclusively** from `room_info.user_count`
- This field was verified to match the TikTok website’s live viewer number
- All other counters were removed:
  - `total_user`
  - `watch_user_count`
  - popularity / UV / PV / replay / totals
  - `RoomUserSeqEvent` values (cumulative on this TikTokLive build)

---

### 🔁 Reliable Polling (No Stale Values)

- Viewer count is refreshed via **room info polling every 5 seconds**
- Each poll:
  - Attempts a **fresh room-info fetch** using all known public and internal TikTokLive fetch methods
  - Automatically adapts to methods that require `room_id` vs no arguments
  - Avoids falling back to cached client attributes that can go stale
- If a fresh fetch is not possible, the sidecar:
  - Logs a warning
  - Still re-emits the last known viewer value so downstream consumers continue updating

---

### 🔄 Guaranteed Re-Emission (Downstream Safety)

- `tiktok.stats` is now emitted **on every poll**, even if the viewer count is unchanged
- Ensures:
  - The `viewers` field is **rewritten each poll**
  - No stale values in aggregators, overlays, or WebView clients
  - First correct value is not “stuck” indefinitely

---

### 🧹 Simplified & Safer Code

- Removed complex heuristics and scoring logic
- Reduced viewer extraction to a **single, explicit source of truth**
- Centralized and hardened room-info fetch logic
- Cleaner, easier-to-maintain sidecar logic

---

### 🛡️ Robustness Improvements

- Graceful handling of TikTok signer failures (500 / 504)
  - Automatic retry with capped backoff
- Pipe-safe stdout handling
  - Prevents crashes when piped to `findstr` / PowerShell
- One-shot debug logging if `user_count` is missing
  - Helps diagnose future TikTokLive API changes
  - Avoids log spam during normal operation

---

## Behavior After This PR

- Viewer count:
  - Updates every 5 seconds
  - Matches the TikTok website
  - Is actively refreshed (no cached reuse)
  - Is re-emitted every poll (no stale downstream state)
- No jumps to cumulative or popularity values
- Sidecar continues running through transient TikTok API/signer failures
- No dependency on `RoomUserSeqEvent` for viewer metrics

---

## Notes

This implementation is intentionally conservative and scoped:

- It reports **only** the concurrent viewer count
- Additional metrics (total viewers, popularity, etc.) can be added later if needed
- Those metrics are intentionally excluded here to avoid ambiguity and incorrect reporting