### PR TITLE
Merged Chat + Event Alerts (App + Overlay)

### DIFF
--- a/Mode-S Client/Mode-S Client.vcxproj
+++ b/Mode-S Client/Mode-S Client.vcxproj
@@ -216,6 +216,7 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
     <None Include="assets\app\app.js" />
     <None Include="assets\app\chat.html" />
     <None Include="assets\app\index.html" />
+    <None Include="assets\mergedChatFeed.js" />
     <None Include="assets\overlay\Common\chat.html" />
     <None Include="assets\overlay\landscape\26_chat.html" />
     <None Include="assets\overlay\landscape\26_footer.html" />

--- a/Mode-S Client/Mode-S Client.vcxproj.filters
+++ b/Mode-S Client/Mode-S Client.vcxproj.filters
@@ -99,6 +99,9 @@
     <ClInclude Include="src\platform\PlatformControl.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="integrations\twitch\TwitchEventSubWsClient.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="integrations\obs\ObsWsClient.cpp">
@@ -144,6 +147,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\platform\PlatformControl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="integrations\twitch\TwitchEventSubWsClient.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -197,6 +203,9 @@
     </None>
     <None Include="assets\overlay\landscape\26_webcam.html">
       <Filter>assets\overlay\landscape</Filter>
+    </None>
+    <None Include="assets\mergedChatFeed.js">
+      <Filter>assets</Filter>
     </None>
   </ItemGroup>
 </Project>

--- a/Mode-S Client/assets/app/chat.html
+++ b/Mode-S Client/assets/app/chat.html
@@ -7,7 +7,7 @@
     <style>
         /* Minimal styling to ensure the log is scrollable in OBS browser sources */
         html, body { margin: 0; padding: 0; height: 100%; background: transparent; overflow: hidden; }
-        body { font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif; color: #fff; }
+        body { font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif; color: #000; }
         /* Make the log take full viewport width and be scrollable vertically. Hide scrollbars visually but keep scrolling. */
         #log { padding: 8px; overflow-y: auto; height: 100vh; box-sizing: border-box; width: 100vw; scroll-behavior: smooth; }
         #log .line { margin: 2px 0; display: flex; align-items: flex-start; }
@@ -40,28 +40,25 @@
         /* Hide scrollbar for IE, Edge */
         #log { -ms-overflow-style: none; }
     
-        /* EventSub alerts rendered like chat lines, but highlighted */
-        #log .line.event {
+        /* Event alert styling (EventSub merged into chat feed) */
+        .line.event {
             background: #025492;
             color: #fff;
+            border-radius: 10px;
             padding: 4px 6px;
-            border-radius: 6px;
         }
-        #log .line.event .text,
-        #log .line.event .text span,
-        #log .line.event .user {
+        .line.event .text, .line.event .text span, .line.event .user {
             color: #fff !important;
         }
-
+    
 </style>
+  <script src="/assets/mergedChatFeed.js"></script>
 </head>
 <body>
     <div id="log"></div>
 
     <script>
         const LOG = document.getElementById("log");
-
-        const EVENTS_ENDPOINT = "/api/twitch/eventsub/events?limit=200";
 
         const ENDPOINTS = [
             "/api/chat?limit=200",
@@ -120,33 +117,31 @@
             const ts = pick(m, ["ts_ms","timestamp","ts","time","created_at"], Date.now());
             const color = String(pick(m, ["color","user_color"], ""));
             const id = String(pick(m, ["id","message_id","msg_id","uuid"], platform + "|" + user + "|" + ts + "|" + text));
-            return { platform, user, text, ts, id, color, raw: m };
+            return { platform, user, text, ts, id, color, raw: m, is_event: false };
         }
 
-        function normalizeEvent(e) {
-            // EventSub events from /api/twitch/eventsub/events
-            // Expected: { platform, type, user, message, ts_ms }
-            const platform = String(e?.platform || "twitch").toLowerCase();
-            const user = String(e?.user || "");
-            const text = String(e?.message || e?.type || "");
-            const ts = Number(e?.ts_ms || Date.now());
-            const type = String(e?.type || "");
-            // Stable-ish id for dedupe
-            const id = `ev:${platform}:${type}:${user}:${ts}:${text}`;
-            return { platform, user, text, ts, color: "", id, is_event: true };
+        function normalizeEvent(raw) {
+            const e = (raw && raw.data && typeof raw.data === "object") ? raw.data : raw;
+            const platform = String(pick(e, ["platform"], "twitch")).toLowerCase() || "twitch";
+            const type = String(pick(e, ["type"], "event"));
+            const user = String(pick(e, ["user","username","display_name","name"], ""));
+            const msg = String(pick(e, ["message","text"], type));
+            const ts = pick(e, ["ts_ms","timestamp","ts","time","created_at"], Date.now());
+            const id = "event|" + platform + "|" + type + "|" + user + "|" + ts + "|" + msg;
+            return { platform, user, text: msg, ts, id, color: "", raw: e, is_event: true, event_type: type };
         }
 
         async function fetchEventsSafe() {
             try {
-                const r = await fetch(EVENTS_ENDPOINT, { cache: "no-store" });
+                const r = await fetch("/api/twitch/eventsub/events?limit=200", { cache: "no-store" });
                 if (!r.ok) return [];
                 const j = await r.json();
-                return Array.isArray(j?.events) ? j.events : [];
+                const evs = Array.isArray(j?.events) ? j.events : [];
+                return evs;
             } catch (e) {
                 return [];
             }
         }
-
 
         function remember(id) {
             if (!id) return false;
@@ -159,8 +154,7 @@
             }
             return true;
         }
-
-        // Deterministic color generator from username
+// Deterministic color generator from username
         function colorFromName(name) {
             if (!name) return '';
             // simple hash
@@ -192,7 +186,8 @@
 
         function addLine(n) {
             if (!n.text) return;
-            const line = document.createElement('div'); line.className = 'line' + (n.is_event ? ' event' : '');
+            const line = document.createElement('div'); line.className = 'line';
+            if (n.is_event) line.classList.add('event');
             const icon = iconFor(n.platform); line.appendChild(icon);
 
             const txt = document.createElement('div'); txt.className = 'text';
@@ -200,6 +195,7 @@
             const userSpan = document.createElement('span');
             userSpan.className = 'user';
             userSpan.textContent = n.user;
+            if (n.is_event) { try { userSpan.style.color = '#fff'; } catch (e) {} }
             if (!n.is_event && n.platform && n.platform.indexOf('twitch') === 0) {
                 const provided = (n.color || '').trim();
                 const col = provided || colorFromName(n.user);
@@ -239,39 +235,62 @@
         }
 
         async function poll() {
-            try {
-                const [{ data }, evs] = await Promise.all([
-                    fetchFirstWorkingEndpoint(),
-                    fetchEventsSafe()
-                ]);
+    // This function is kept for compatibility, but the actual work is delegated
+    // to the shared MergedChatFeed module.
+}
 
-                const msgs = extractMessages(data);
-                const merged = [];
 
-                for (const raw of msgs) {
-                    const n = normalize(raw);
-                    if (!n.text) continue;
-                    n.is_event = false;
-                    merged.push(n);
-                }
 
-                for (const e of (evs || [])) {
-                    const n = normalizeEvent(e);
-                    if (!n.text) continue;
-                    merged.push(n);
-                }
 
-                merged.sort((a, b) => (Number(a.ts) || 0) - (Number(b.ts) || 0));
+    
 
-                for (const n of merged) {
-                    if (remember(n.id)) addLine(n);
-                }
-            } catch (e) {
-                console.error('chat poll error:', e);
-            }
+// ---- merged chat + EventSub events feed ----
+let __mergedFeedTimer = null;
+function startMergedFeed() {
+    if (__mergedFeedTimer) clearInterval(__mergedFeedTimer);
+
+    __mergedFeedTimer = MergedChatFeed.start({
+        intervalMs: 1000,
+        maxItems: 200,
+        dedupeWindowMs: 5000,
+
+        // Chat fetch returns the JSON used by this page.
+        fetchChat: async () => {
+            const r = await fetchFirstWorkingEndpoint();
+            return r.data ?? r;
+        },
+
+        // Event fetch returns {count, events:[...]}
+        fetchEvents: async () => {
+            return await fetchEventsSafe();
+        },
+
+        // Convert chat JSON into raw message items.
+        extractChatItems: (chatJson) => extractMessages(chatJson),
+
+        // Normalize chat raw item into a common shape
+        normalizeChatItem: (raw) => {
+            const n = normalize(raw);
+            if (!n) return n;
+            n.is_event = false;
+            return n;
+        },
+
+        // Normalize EventSub event into a common shape
+        normalizeEventItem: (raw) => normalizeEvent(raw),
+
+        remember,
+        addLine,
+
+        onError: (e) => {
+            // Keep overlay quiet; app can log to console
+            if (typeof console !== "undefined" && console.error) console.error("merged feed error:", e);
         }
+    });
+}
 
-        (async () => { await preloadIcons(); window.addEventListener('load', () => { if (LOG.lastElementChild) LOG.lastElementChild.scrollIntoView(); }); poll(); setInterval(poll, POLL_MS); })();
-    </script>
+startMergedFeed();
+
+</script>
 </body>
 </html>

--- a/Mode-S Client/assets/mergedChatFeed.js
+++ b/Mode-S Client/assets/mergedChatFeed.js
@@ -1,0 +1,123 @@
+// /assets/mergedChatFeed.js
+// Shared merge logic for chat + EventSub events.
+// Consumers provide small hooks (fetchChat, extractChatItems, normalizeChatItem, normalizeEventItem, remember, addLine).
+(function () {
+  "use strict";
+
+  function buildEventIndex(eventNorms) {
+    const map = new Map();
+    for (const e of (eventNorms || [])) {
+      const p = (e.platform ? e.platform : "").toLowerCase();
+      const u = (e.user ? e.user : "").toLowerCase();
+      const t = (e.text ? e.text : "").toLowerCase();
+      const key = p + "|" + u + "|" + t;
+      const arr = map.get(key) || [];
+      arr.push(Number(e.ts) || 0);
+      map.set(key, arr);
+    }
+    for (const [k, arr] of map.entries()) arr.sort((a, b) => a - b);
+    return map;
+  }
+
+  function hasNearTimestamp(sortedArr, ts, windowMs) {
+    if (!sortedArr || !sortedArr.length) return false;
+    const lo = ts - windowMs, hi = ts + windowMs;
+    let l = 0, r = sortedArr.length - 1;
+    while (l <= r) {
+      const mid = (l + r) >> 1;
+      const v = sortedArr[mid];
+      if (v < lo) l = mid + 1;
+      else if (v > hi) r = mid - 1;
+      else return true;
+    }
+    return false;
+  }
+
+  function isChatDuplicateOfEvent(chatNorm, eventIndex, windowMs) {
+    if (!chatNorm || chatNorm.is_event) return false;
+    if ((chatNorm.platform || "").toLowerCase() !== "twitch") return false; // only suppress for Twitch
+    const p = (chatNorm.platform ? chatNorm.platform : "").toLowerCase();
+    const u = (chatNorm.user ? chatNorm.user : "").toLowerCase();
+    const t = (chatNorm.text ? chatNorm.text : "").toLowerCase();
+    const key = p + "|" + u + "|" + t;
+    const arr = eventIndex.get(key);
+    if (!arr) return false;
+    const ts = Number(chatNorm.ts) || 0;
+    return hasNearTimestamp(arr, ts, windowMs);
+  }
+
+  async function safeCall(fn, fallback) {
+    try { return await fn(); } catch (_) { return fallback; }
+  }
+
+  async function tick(cfg) {
+    const {
+      fetchChat,
+      fetchEvents,
+      extractChatItems,
+      normalizeChatItem,
+      normalizeEventItem,
+      remember,
+      addLine,
+      onError,
+      maxItems = 200,
+      dedupeWindowMs = 5000
+    } = cfg;
+
+    try {
+      const [chatJson, eventsJson] = await Promise.all([
+        safeCall(fetchChat, null),
+        safeCall(fetchEvents, null)
+      ]);
+
+      const chatItemsRaw = extractChatItems ? (extractChatItems(chatJson) || []) : [];
+      const eventsRaw = (eventsJson && eventsJson.events) ? eventsJson.events : (eventsJson || []);
+
+      // Normalize events first (needed for duplicate suppression)
+      const eventNorms = [];
+      for (const e of eventsRaw) {
+        const n = normalizeEventItem(e);
+        if (!n || !n.text) continue;
+        n.is_event = true;
+        eventNorms.push(n);
+      }
+      const eventIndex = buildEventIndex(eventNorms);
+
+      const merged = [];
+
+      for (const raw of chatItemsRaw) {
+        const n = normalizeChatItem(raw);
+        if (!n || !n.text) continue;
+        n.is_event = !!n.is_event; // preserve if caller sets it
+        if (isChatDuplicateOfEvent(n, eventIndex, dedupeWindowMs)) continue;
+        merged.push(n);
+      }
+
+      for (const n of eventNorms) merged.push(n);
+
+      merged.sort((a, b) => (Number(a.ts) || 0) - (Number(b.ts) || 0));
+
+      const slice = merged.slice(-maxItems);
+      for (const n of slice) {
+        if (!n.id) {
+          // Best-effort stable id
+          n.id = `${n.is_event ? "ev" : "ch"}:${(n.platform || "")}:${(n.user || "")}:${(n.ts || 0)}:${(n.text || "")}`.slice(0, 512);
+        }
+        if (remember(n.id)) addLine(n);
+      }
+    } catch (e) {
+      if (onError) onError(e);
+    }
+  }
+
+  function start(cfg) {
+    if (!cfg) throw new Error("MergedChatFeed.start: missing cfg");
+    const intervalMs = cfg.intervalMs || 1000;
+    const run = () => tick(cfg);
+    // run immediately
+    run();
+    return setInterval(run, intervalMs);
+  }
+
+  window.MergedChatFeed = { start };
+})();

--- a/Mode-S Client/assets/overlay/common/chat.html
+++ b/Mode-S Client/assets/overlay/common/chat.html
@@ -42,7 +42,7 @@
     
         /* Event alert styling (EventSub merged into chat feed) */
         .line.event {
-            background: rgba(2, 84, 146, 0.85);
+            background: #025492;
             color: #fff;
             border-radius: 10px;
             padding: 4px 6px;
@@ -52,6 +52,7 @@
         }
     
 </style>
+  <script src="/assets/mergedChatFeed.js"></script>
 </head>
 <body>
     <div id="log"></div>
@@ -153,8 +154,7 @@
             }
             return true;
         }
-
-        // Deterministic color generator from username
+// Deterministic color generator from username
         function colorFromName(name) {
             if (!name) return '';
             // simple hash
@@ -235,33 +235,62 @@
         }
 
         async function poll() {
-            try {
-                const { url, data } = await fetchFirstWorkingEndpoint();
-                const msgs = extractMessages(data);
-                const evs = await fetchEventsSafe();
+    // This function is kept for compatibility, but the actual work is delegated
+    // to the shared MergedChatFeed module.
+}
 
-                const toAdd = [];
-                for (const raw of msgs) {
-                    const n = normalize(raw);
-                    if (!n.text) continue;
-                    if (remember(n.id)) toAdd.push(n);
-                }
-                for (const raw of evs) {
-                    const n = normalizeEvent(raw);
-                    if (!n.text) continue;
-                    if (remember(n.id)) toAdd.push(n);
-                }
 
-                if (!toAdd.length) return;
-                toAdd.sort((a,b) => (Number(a.ts)||0) - (Number(b.ts)||0));
-                for (const n of toAdd) addLine(n);
-                // no page reload; DOM updates with smooth scroll are used
-            } catch (e) {
-                console.error('chat poll error:', e);
-            }
+
+
+    
+
+// ---- merged chat + EventSub events feed ----
+let __mergedFeedTimer = null;
+function startMergedFeed() {
+    if (__mergedFeedTimer) clearInterval(__mergedFeedTimer);
+
+    __mergedFeedTimer = MergedChatFeed.start({
+        intervalMs: 1000,
+        maxItems: 200,
+        dedupeWindowMs: 5000,
+
+        // Chat fetch returns the JSON used by this page.
+        fetchChat: async () => {
+            const r = await fetchFirstWorkingEndpoint();
+            return r.data ?? r;
+        },
+
+        // Event fetch returns {count, events:[...]}
+        fetchEvents: async () => {
+            return await fetchEventsSafe();
+        },
+
+        // Convert chat JSON into raw message items.
+        extractChatItems: (chatJson) => extractMessages(chatJson),
+
+        // Normalize chat raw item into a common shape
+        normalizeChatItem: (raw) => {
+            const n = normalize(raw);
+            if (!n) return n;
+            n.is_event = false;
+            return n;
+        },
+
+        // Normalize EventSub event into a common shape
+        normalizeEventItem: (raw) => normalizeEvent(raw),
+
+        remember,
+        addLine,
+
+        onError: (e) => {
+            // Keep overlay quiet; app can log to console
+            if (typeof console !== "undefined" && console.error) console.error("merged feed error:", e);
         }
+    });
+}
 
-        (async () => { await preloadIcons(); window.addEventListener('load', () => { if (LOG.lastElementChild) LOG.lastElementChild.scrollIntoView(); }); poll(); setInterval(poll, POLL_MS); })();
-    </script>
+startMergedFeed();
+
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

This PR updates both `/app/chat.html` and `/overlay/chat.html` to display a **single merged feed** of:

- normal chat messages (from the existing chat API), and
- Twitch EventSub events (from `/api/twitch/eventsub/events`)

Event items are rendered **in-line like chat messages**, but styled as alerts with a **blue background (`#025492`) and white text**, keeping chat readable while still surfacing key stream events.

---

## Key Changes

### ✅ Shared merge logic
- Added a shared client-side module: **`/assets/mergedChatFeed.js`**
- Centralizes the logic to:
  - poll chat + events
  - normalize into a common shape
  - merge + sort by timestamp
  - de-duplicate
  - suppress duplicate “chat echoes” of EventSub events (show *only* the event)

### ✅ App + Overlay updated
- Updated **`/app/chat.html`** and **`/overlay/chat.html`** to:
  - load `/assets/mergedChatFeed.js`
  - provide page-specific hooks (fetch + render)
  - start the merged feed loop

### ✅ Event alert styling
- Event items are rendered with:
  - background: `#025492`
  - text: `#ffffff`
- They use the same layout as chat lines to keep formatting consistent.

---

## Behavior Notes

### Duplicate suppression (important)
When an EventSub event is also present in chat (e.g. a follow echoed into chat), the UI will:
- **hide the chat copy**
- **show only the event alert** (blue styling)

This prevents duplicated entries in the merged feed.

---

## Testing

1. Start Mode-S Client and ensure Twitch EventSub is running.
2. Open:
   - `/app/chat.html`
   - `/overlay/chat.html`
3. Trigger a Twitch follow (or sub/gift if enabled).
4. Confirm:
   - the event appears as a blue alert item
   - it does **not** appear twice (chat + event)

---

## Files Changed / Added

**Added**
- `/assets/mergedChatFeed.js`

**Updated**
- `/app/chat.html`
- `/overlay/chat.html`
