### PR TITLE
Enable TikTok Bot Replies via Sidecar

### DIFF
--- a/Mode-S Client/integrations/tiktok/TikTokSidecar.h
+++ b/Mode-S Client/integrations/tiktok/TikTokSidecar.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <thread>
 #include <atomic>
+#include <mutex>
 #include <windows.h>
 #include "json.hpp"
 
@@ -19,12 +20,24 @@ public:
 
     void stop();
 
+    // Step 2: ask the python sidecar to send a message into TikTok LIVE chat.
+    // Returns false if the sidecar isn't running or if the write fails.
+    bool send_chat(const std::string& text);
+
 private:
     void reader_loop();
 
     PROCESS_INFORMATION pi_{};
+
+    // Python stdout -> C++ reads (events)
     HANDLE hStdOutRd_{ nullptr };
     HANDLE hStdOutWr_{ nullptr };
+
+    // C++ -> Python stdin (commands, e.g. send_chat)
+    HANDLE hStdInRd_{ nullptr };
+    HANDLE hStdInWr_{ nullptr };
+    std::mutex stdin_mu_;
+
     std::thread reader_;
     std::atomic<bool> running_{ false };
     EventHandler onEvent_;

--- a/Mode-S Client/src/Mode-S Client.cpp
+++ b/Mode-S Client/src/Mode-S Client.cpp
@@ -1403,7 +1403,7 @@ switch (msg) {
         //   are treated as false here. The test endpoint can simulate roles.
         if (!botSubscribed) {
             botSubscribed = true;
-            chat.Subscribe([pChat=&chat, pState=&state, pTwitch=&twitch](const ChatMessage& m) {
+            chat.Subscribe([pChat=&chat, pState=&state, pTwitch=&twitch, pTikTok = &tiktok](const ChatMessage& m) {
                 // Avoid responding to ourselves.
                 if (m.user == "StreamingATC.Bot") return;
                 if (m.message.size() < 2 || m.message[0] != '!') return;
@@ -1511,6 +1511,12 @@ switch (msg) {
                 if (platform_lc == "twitch" && pTwitch) {
                     if (!pTwitch->SendPrivMsg(reply)) {
                         OutputDebugStringA("[BOT] Twitch send failed\n");
+                    }
+                }
+                // Send back to the origin platform (Tiktok).
+                if (platform_lc == "tiktok" && pTikTok) {
+                    if (!pTikTok->send_chat(reply)) {
+                        OutputDebugStringA("[BOT] TikTok send failed (sidecar)\n");
                     }
                 }
 


### PR DESCRIPTION
## Summary

This PR completes **Step 2** of the TikTok chatbot work:

> When a viewer types a bot command in TikTok chat (e.g. `!discord`), the bot now attempts to reply **directly back into TikTok Live chat**, not just in the app/overlay.

The implementation is deliberately cautious and safe:
- No existing inbound TikTok functionality was changed
- Twitch behaviour is unchanged
- If TikTok chat sending is not supported by the installed TikTokLive build, the system fails gracefully with clear logs

---

## What Changed

### 1. TikTok sidecar (Python)
**File:** `tiktok_sidecar.py`

- Added support for receiving commands from C++ over stdin
- Implemented `send_chat` handling:
  - Attempts to send a message using whatever send method exists in the installed TikTokLive build
  - Uses existing config keys:
    - `tiktok_sessionid`
    - `tiktok_sessionid_ss`
- Emits structured results back to C++:
  - `tiktok.send_result { ok: true | false }`
- Removed unreachable legacy code below `SystemExit(main())`

This keeps all TikTok-specific complexity isolated in the sidecar.

---

### 2. TikTok sidecar (C++)
**Files:**
- `TikTokSidecar.h`
- `TikTokSidecar.cpp`

- Added a stdin pipe from C++ → Python
- Added a new method:
  ```cpp
  bool TikTokSidecar::send_chat(const std::string& text);
  ```
- The sidecar now supports **two-way communication**:
  - Python → C++ (events, stats, logs)
  - C++ → Python (send chat requests)

No existing behaviour was removed.

---

### 3. Bot command handler
**File:** `Mode-S Client.cpp`

- Extended the existing bot command handler so that:
  - Twitch replies still use `SendPrivMsg(...)`
  - TikTok replies now call:
    ```cpp
    tiktok.send_chat(reply);
    ```
- The bot continues to inject replies into the unified `ChatAggregator` first (so overlays and UI remain consistent)

This keeps platform-specific sending logic minimal and explicit.

---

## How It Works (High Level)

1. Viewer types `!command` in TikTok Live chat
2. TikTokLive → Python sidecar emits a `tiktok.chat` event
3. C++ ingests the event into `ChatAggregator`
4. Bot command handler resolves the command
5. Bot reply is:
   - Added to the app/overlay chat feed
   - Sent back to TikTok via `TikTokSidecar::send_chat()`
6. Python sidecar attempts to post into TikTok Live chat

If TikTokLive does not support sending chat in the current environment:
- The reply still appears in the app/overlay
- A warning is logged (no crash, no spam)

---

## Configuration

No new config keys were added.

This PR reuses existing keys:
```json
"tiktok_sessionid": "...",
"tiktok_sessionid_ss": "..."
```

These are required for TikTokLive “privileged” operations and outbound chat attempts.