### PR TITLE
EventSub self-healing + health/status API (fixes #53, #59)

### DIFF
--- a/Mode-S Client/integrations/twitch/TwitchEventSubWsClient.cpp
+++ b/Mode-S Client/integrations/twitch/TwitchEventSubWsClient.cpp
@@ -136,98 +136,32 @@ static bool IsAllDigits(const std::string& s)
 
 static bool ParseWssUrl(const std::wstring& url, std::wstring& hostOut, std::wstring& pathOut)
 {
-    // Twitch may provide a reconnect_url with the "wss" scheme. WinHttpCrackUrl
-    // is not guaranteed to understand that scheme on all Windows versions.
-    // We'll try WinHttpCrackUrl first, then fall back to a manual parse.
-
-    auto manual_parse = [&]() -> bool {
-        std::wstring u = url;
-        // Trim whitespace
-        while (!u.empty() && iswspace(u.front())) u.erase(u.begin());
-        while (!u.empty() && iswspace(u.back())) u.pop_back();
-
-        // Normalize leading scheme to lowercase for comparison.
-        auto starts_with_i = [&](const std::wstring& prefix) -> bool {
-            if (u.size() < prefix.size()) return false;
-            for (size_t i = 0; i < prefix.size(); ++i) {
-                wchar_t a = (wchar_t)towlower(u[i]);
-                wchar_t b = (wchar_t)towlower(prefix[i]);
-                if (a != b) return false;
-            }
-            return true;
-        };
-
-        const std::wstring wss = L"wss://";
-        const std::wstring https = L"https://";
-        const std::wstring http = L"http://";
-
-        size_t off = 0;
-        if (starts_with_i(wss)) off = wss.size();
-        else if (starts_with_i(https)) off = https.size();
-        else if (starts_with_i(http)) off = http.size();
-        else {
-            // Some providers may omit a scheme; assume wss.
-            off = 0;
-        }
-
-        // host[:port]/path?query
-        size_t slash = u.find(L'/', off);
-        size_t qmark = u.find(L'?', off);
-        // Avoid Windows min/max macros (NOMINMAX may not be set in this TU).
-        const size_t slash_pos = (slash == std::wstring::npos) ? u.size() : slash;
-        const size_t qmark_pos = (qmark == std::wstring::npos) ? u.size() : qmark;
-        size_t host_end = (slash_pos < qmark_pos) ? slash_pos : qmark_pos;
-        if (host_end <= off) return false;
-
-        std::wstring host = u.substr(off, host_end - off);
-        // Strip :port if present (we always connect 443 for wss)
-        size_t colon = host.find(L':');
-        if (colon != std::wstring::npos) host = host.substr(0, colon);
-        if (host.empty()) return false;
-
-        std::wstring path;
-        if (slash != std::wstring::npos) {
-            path = u.substr(slash);
-        } else if (qmark != std::wstring::npos) {
-            // URL has no slash but has a query - treat as /?query
-            path = L"/" + u.substr(qmark);
-        } else {
-            path = L"/ws";
-        }
-
-        hostOut = std::move(host);
-        pathOut = std::move(path);
-        return true;
-    };
-
     URL_COMPONENTS uc{};
     uc.dwStructSize = sizeof(uc);
 
     wchar_t host[256] = {};
     wchar_t path[1024] = {};
-    wchar_t extra[2048] = {};
     uc.lpszHostName = host;
     uc.dwHostNameLength = (DWORD)std::size(host);
     uc.lpszUrlPath = path;
     uc.dwUrlPathLength = (DWORD)std::size(path);
-    uc.lpszExtraInfo = extra;
-    uc.dwExtraInfoLength = (DWORD)std::size(extra);
 
-    if (!WinHttpCrackUrl(url.c_str(), (DWORD)url.size(), 0, &uc)) {
-        return manual_parse();
-    }
-    if (uc.dwHostNameLength == 0) {
-        return manual_parse();
-    }
+    // Note: WinHttpCrackUrl expects a scheme like "wss://"
+    if (!WinHttpCrackUrl(url.c_str(), (DWORD)url.size(), 0, &uc))
+        return false;
+
+    if (uc.dwHostNameLength == 0)
+        return false;
 
     hostOut.assign(uc.lpszHostName, uc.dwHostNameLength);
 
+    // Include extra info (query) if present
     std::wstring p;
-    if (uc.dwUrlPathLength > 0) p.assign(uc.lpszUrlPath, uc.dwUrlPathLength);
-    std::wstring ex;
-    if (uc.dwExtraInfoLength > 0) ex.assign(uc.lpszExtraInfo, uc.dwExtraInfoLength);
-    if (p.empty()) p = L"/ws";
-    pathOut = p + ex;
+    if (uc.dwUrlPathLength > 0)
+        p.assign(uc.lpszUrlPath, uc.dwUrlPathLength);
+    if (p.empty())
+        p = L"/ws";
+    pathOut = p;
     return true;
 }
 
@@ -264,8 +198,6 @@ void TwitchEventSubWsClient::Start(
     JsonCallback onStatus)
 {
     Stop();
-
-    std::lock_guard<std::mutex> lk_life(lifecycle_mu_);
 
     client_id_ = clientId;
     access_token_ = NormalizeRawAccessToken(userAccessToken);
@@ -307,42 +239,22 @@ void TwitchEventSubWsClient::Start(
 
 void TwitchEventSubWsClient::Stop()
 {
-    std::thread to_join;
+    running_ = false;
 
+    // Unblock WinHttpWebSocketReceive if it's waiting.
     {
-        // Make Stop() safe to call from multiple threads (HTTP routes, token refresh, UI).
-    
-        running_ = false;
-        // Bump epoch so any watchdog threads exit promptly.
-        run_epoch_.fetch_add(1);
-
-        // Unblock WinHttpWebSocketReceive if it's waiting.
-        {
-            std::lock_guard<std::mutex> lk(ws_mu_);
-            if (ws_handle_) {
-                HINTERNET ws = static_cast<HINTERNET>(ws_handle_);
-                // Best-effort close; ignore errors.
-                WinHttpWebSocketClose(ws, 1000, nullptr, 0);
-                WinHttpCloseHandle(ws);
-                ws_handle_ = nullptr;
-            }
-        }
-
-        // Move the worker thread out under the lifecycle lock. Join outside.
-        if (worker_.joinable()) {
-            to_join = std::move(worker_);
+        std::lock_guard<std::mutex> lk(ws_mu_);
+        if (ws_handle_) {
+            HINTERNET ws = static_cast<HINTERNET>(ws_handle_);
+            // Best-effort close; ignore errors.
+            WinHttpWebSocketClose(ws, 1000, nullptr, 0);
+            WinHttpCloseHandle(ws);
+            ws_handle_ = nullptr;
         }
     }
 
-    if (to_join.joinable()) {
-        if (to_join.get_id() == std::this_thread::get_id()) {
-            // Never self-join; detach as a last resort.
-            to_join.detach();
-        }
-        else {
-            to_join.join();
-        }
-    }
+    if (worker_.joinable())
+        worker_.join();
 
     {
         std::lock_guard<std::mutex> lk(status_mu_);
@@ -350,11 +262,9 @@ void TwitchEventSubWsClient::Stop()
         connected_ = false;
         subscribed_ = false;
         session_id_.clear();
-        keepalive_timeout_sec_ = 0;
     }
     EmitStatus();
 }
-
 
 
 void TwitchEventSubWsClient::UpdateAccessToken(const std::string& userAccessToken)
@@ -429,12 +339,7 @@ void TwitchEventSubWsClient::RequestReconnect(const std::wstring& wssUrl)
 {
     std::wstring host, path;
     if (!ParseWssUrl(wssUrl, host, path)) {
-        // Helpful diagnostic: log the URL (trimmed) so we can see what Twitch sent.
-        std::wstring u = wssUrl;
-        while (!u.empty() && iswspace(u.front())) u.erase(u.begin());
-        while (!u.empty() && iswspace(u.back())) u.pop_back();
-        if (u.size() > 240) u = u.substr(0, 240) + L"...";
-        OutputDebug(L"session_reconnect: failed to parse reconnect_url: " + u);
+        OutputDebug(L"session_reconnect: failed to parse reconnect_url");
         return;
     }
 
@@ -459,12 +364,8 @@ void TwitchEventSubWsClient::RequestReconnect(const std::wstring& wssUrl)
 
 void TwitchEventSubWsClient::Run()
 {
-    int attempt = 0;
-
     while (running_)
     {
-        const std::uint64_t epoch = run_epoch_.load();
-
         std::wstring host, path;
         {
             std::lock_guard<std::mutex> lk(reconnect_mu_);
@@ -480,8 +381,6 @@ void TwitchEventSubWsClient::Run()
             connected_ = false;
             subscribed_ = false;
             session_id_.clear();
-            keepalive_timeout_sec_ = 0;
-            last_error_.clear();
         }
         EmitStatus();
 
@@ -490,28 +389,6 @@ void TwitchEventSubWsClient::Run()
         HINTERNET hRequest = nullptr;
         HINTERNET hWebSocket = nullptr;
 
-        auto cleanup = [&]() {
-            {
-                std::lock_guard<std::mutex> lk(ws_mu_);
-                if (ws_handle_ == hWebSocket) {
-                    ws_handle_ = nullptr;
-                }
-            }
-            if (hWebSocket) WinHttpCloseHandle(hWebSocket);
-            if (hRequest)   WinHttpCloseHandle(hRequest);
-            if (hConnect)   WinHttpCloseHandle(hConnect);
-            if (hSession)   WinHttpCloseHandle(hSession);
-            hWebSocket = nullptr; hRequest = nullptr; hConnect = nullptr; hSession = nullptr;
-        };
-
-        auto fail = [&](const std::string& what) {
-            SetLastError(what);
-            cleanup();
-        };
-
-        bool connected_ok = false;
-
-        // ---- connect attempt (no goto; use connected_ok flag) ----
         hSession = WinHttpOpen(
             L"ModeS-Twitch-EventSub/1.0",
             WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
@@ -520,158 +397,132 @@ void TwitchEventSubWsClient::Run()
             0);
 
         if (!hSession) {
-            fail("WinHttpOpen failed");
-        } else {
-
-            // Ensure modern TLS is enabled (Twitch requires TLS 1.2+).
-            DWORD protocols = WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2;
-#ifdef WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_3
-            protocols |= WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_3;
-#endif
-            WinHttpSetOption(hSession, WINHTTP_OPTION_SECURE_PROTOCOLS, &protocols, sizeof(protocols));
-
-            hConnect = WinHttpConnect(hSession, host.c_str(), INTERNET_DEFAULT_HTTPS_PORT, 0);
-            if (!hConnect) {
-                fail("WinHttpConnect failed");
-            } else {
-
-                hRequest = WinHttpOpenRequest(
-                    hConnect,
-                    L"GET",
-                    path.c_str(),
-                    nullptr,
-                    WINHTTP_NO_REFERER,
-                    WINHTTP_DEFAULT_ACCEPT_TYPES,
-                    WINHTTP_FLAG_SECURE);
-
-                if (!hRequest) {
-                    fail("WinHttpOpenRequest failed");
-                } else {
-
-                    // Tell WinHTTP this request will upgrade to a WebSocket.
-                    if (!WinHttpSetOption(hRequest, WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET, nullptr, 0)) {
-                        fail("WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET failed");
-                    } else {
-
-                        if (!WinHttpSendRequest(
-                            hRequest,
-                            WINHTTP_NO_ADDITIONAL_HEADERS,
-                            0,
-                            WINHTTP_NO_REQUEST_DATA,
-                            0,
-                            0,
-                            0))
-                        {
-                            fail("WinHttpSendRequest failed");
-                        }
-                        else if (!WinHttpReceiveResponse(hRequest, nullptr)) {
-                            fail("WinHttpReceiveResponse failed");
-                        }
-                        else {
-
-                            hWebSocket = WinHttpWebSocketCompleteUpgrade(hRequest, 0);
-                            hRequest = nullptr;
-
-                            if (!hWebSocket) {
-                                fail("WinHttpWebSocketCompleteUpgrade failed");
-                            } else {
-
-                                {
-                                    std::lock_guard<std::mutex> lk(ws_mu_);
-                                    ws_handle_ = hWebSocket;
-                                }
-
-                                OutputDebug(L"connected");
-                                {
-                                    std::lock_guard<std::mutex> lk(status_mu_);
-                                    ws_state_ = "connected";
-                                    connected_ = true;
-                                    last_ws_message_ms_ = NowMs();
-                                    last_keepalive_ms_ = NowMs(); // until welcome gives us the real keepalive schedule
-                                }
-                                EmitStatus();
-
-                                // Reset backoff on a successful connect.
-                                attempt = 0;
-
-                                // Watchdog: if keepalives stop arriving, force a reconnect.
-                                std::thread watchdog([this, epoch]() {
-                                    while (running_ && run_epoch_.load() == epoch)
-                                    {
-                                        int timeout_s = 0;
-                                        std::int64_t last_keep_ms = 0;
-                                        bool is_connected = false;
-
-                                        {
-                                            std::lock_guard<std::mutex> lk(status_mu_);
-                                            timeout_s = keepalive_timeout_sec_;
-                                            last_keep_ms = last_keepalive_ms_;
-                                            is_connected = connected_;
-                                        }
-
-                                        if (is_connected && timeout_s > 0 && last_keep_ms > 0) {
-                                            const std::int64_t now = NowMs();
-                                            const std::int64_t grace_ms = 5000; // be generous vs. transient stalls
-                                            const std::int64_t limit = (std::int64_t)timeout_s * 1000 + grace_ms;
-                                            if ((now - last_keep_ms) > limit) {
-                                                SetLastError("keepalive_timeout");
-                                                RequestReconnect(L"wss://eventsub.wss.twitch.tv/ws");
-                                                break;
-                                            }
-                                        }
-
-                                        Sleep(1000);
-                                    }
-                                });
-
-                                connected_ok = true;
-
-                                ReceiveLoop(hWebSocket);
-
-                                // End watchdog for this iteration.
-                                run_epoch_.fetch_add(1);
-                                if (watchdog.joinable()) watchdog.join();
-                            }
-                        }
-                    }
-                }
-            }
+            OutputDebug(L"WinHttpOpen failed");
+            break;
         }
 
-        cleanup();
+        
+        // Ensure modern TLS is enabled (Twitch requires TLS 1.2+).
+        DWORD protocols = WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2;
+        // TLS 1.3 flag is available on newer SDKs; guard with ifdef.
+        #ifdef WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_3
+        protocols |= WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_3;
+        #endif
+        WinHttpSetOption(hSession, WINHTTP_OPTION_SECURE_PROTOCOLS, &protocols, sizeof(protocols));
 
-        if (!running_) break;
+hConnect = WinHttpConnect(
+            hSession,
+            host.c_str(),
+            INTERNET_DEFAULT_HTTPS_PORT,
+            0);
 
-        // ---- reconnect backoff ----
+        if (!hConnect) {
+            OutputDebug(L"WinHttpConnect failed");
+            WinHttpCloseHandle(hSession);
+            break;
+        }
+
+        hRequest = WinHttpOpenRequest(
+            hConnect,
+            L"GET",
+            path.c_str(),
+            nullptr,
+            WINHTTP_NO_REFERER,
+            WINHTTP_DEFAULT_ACCEPT_TYPES,
+            WINHTTP_FLAG_SECURE);
+
+        if (!hRequest) {
+            OutputDebug(L"WinHttpOpenRequest failed");
+            WinHttpCloseHandle(hConnect);
+            WinHttpCloseHandle(hSession);
+            break;
+        }
+
+        
+        // Tell WinHTTP this request will upgrade to a WebSocket.
+        // Without this, WinHttpWebSocketCompleteUpgrade will fail.
+        if (!WinHttpSetOption(hRequest, WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET, nullptr, 0)) {
+            DWORD err = GetLastError();
+            OutputDebug(L"WinHttpSetOption(WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET) failed, err=" + std::to_wstring(err));
+            WinHttpCloseHandle(hRequest);
+            WinHttpCloseHandle(hConnect);
+            WinHttpCloseHandle(hSession);
+            break;
+        }
+
+if (!WinHttpSendRequest(
+            hRequest,
+            WINHTTP_NO_ADDITIONAL_HEADERS,
+            0,
+            WINHTTP_NO_REQUEST_DATA,
+            0,
+            0,
+            0))
+        {
+            OutputDebug(L"WinHttpSendRequest failed, err=" + std::to_wstring(GetLastError()));
+            WinHttpCloseHandle(hRequest);
+            WinHttpCloseHandle(hConnect);
+            WinHttpCloseHandle(hSession);
+            break;
+        }
+
+        if (!WinHttpReceiveResponse(hRequest, nullptr)) {
+            OutputDebug(L"WinHttpReceiveResponse failed, err=" + std::to_wstring(GetLastError()));
+            WinHttpCloseHandle(hRequest);
+            WinHttpCloseHandle(hConnect);
+            WinHttpCloseHandle(hSession);
+            break;
+        }
+
+        hWebSocket = WinHttpWebSocketCompleteUpgrade(hRequest, 0);
+        hRequest = nullptr;
+
+        if (!hWebSocket) {
+            OutputDebug(L"WinHttpWebSocketCompleteUpgrade failed, err=" + std::to_wstring(GetLastError()));
+            WinHttpCloseHandle(hConnect);
+            WinHttpCloseHandle(hSession);
+            break;
+        }
+
+        {
+            std::lock_guard<std::mutex> lk(ws_mu_);
+            ws_handle_ = hWebSocket;
+        }
+
+        OutputDebug(L"connected");
+        {
+            std::lock_guard<std::mutex> lk(status_mu_);
+            ws_state_ = "connected";
+            connected_ = true;
+        }
+        EmitStatus();
+        ReceiveLoop(hWebSocket);
+
+        {
+            std::lock_guard<std::mutex> lk(ws_mu_);
+            if (ws_handle_ == hWebSocket)
+                ws_handle_ = nullptr;
+        }
+
+        WinHttpCloseHandle(hWebSocket);
+        if (hRequest) WinHttpCloseHandle(hRequest);
+        if (hConnect) WinHttpCloseHandle(hConnect);
+        if (hSession) WinHttpCloseHandle(hSession);
+
+        if (!running_)
+            break;
+
+        // If not explicitly asked to reconnect, back off a touch.
         bool wantsReconnect = false;
         {
             std::lock_guard<std::mutex> lk(reconnect_mu_);
             wantsReconnect = reconnect_requested_;
         }
-
-        if (!wantsReconnect) {
-            attempt = (std::min)(attempt + 1, 8);
-        } else {
-            // Twitch asked us to reconnect; keep it snappy.
-            attempt = 0;
-        }
-
-        // base delay: 300ms, cap ~30s
-        DWORD base = 300;
-        DWORD max_delay = 30000;
-
-        DWORD delay = base;
-        if (attempt > 0) {
-            delay = base * (1u << (std::min)(attempt, 6));
-        }
-        if (delay > max_delay) delay = max_delay;
-
-        // jitter up to 250ms
-        DWORD jitter = (DWORD)(GetTickCount64() % 250);
-
-        Sleep(delay + jitter);
+        if (!wantsReconnect)
+            Sleep(750);
     }
 }
+
 void TwitchEventSubWsClient::ReceiveLoop(void* ws)
 {
     HINTERNET hWebSocket = static_cast<HINTERNET>(ws);
@@ -748,8 +599,6 @@ void TwitchEventSubWsClient::HandleMessage(const std::string& payload)
             {
                 std::lock_guard<std::mutex> lk(status_mu_);
                 session_id_ = sessionId;
-                keepalive_timeout_sec_ = pl.contains("session") ? pl["session"].value("keepalive_timeout_seconds", 0) : 0;
-                last_keepalive_ms_ = NowMs();
                 subscribed_ = false;
                 subscriptions_ = json::array();
                 last_error_.clear();
@@ -966,7 +815,7 @@ bool TwitchEventSubWsClient::CreateSubscription(const std::string& type,
         attempt["type"] = type;
         attempt["version"] = version;
         attempt["status"] = r.status;
-        attempt["ok"] = (r.status == 202 || (r.status >= 200 && r.status < 300) || r.status == 409);
+        attempt["ok"] = (r.status == 202 || (r.status >= 200 && r.status < 300));
         if (!r.body.empty()) attempt["body"] = r.body;
         subscriptions_.push_back(attempt);
         if (attempt["ok"].get<bool>()) {
@@ -975,7 +824,7 @@ bool TwitchEventSubWsClient::CreateSubscription(const std::string& type,
     }
     EmitStatus();
 
-    if (r.status == 202 || (r.status >= 200 && r.status < 300) || r.status == 409) {
+    if (r.status == 202 || (r.status >= 200 && r.status < 300)) {
         OutputDebug(L"Subscribed: " + Utf8ToWide(type) + L" v" + Utf8ToWide(version));
         return true;
     }
@@ -997,86 +846,35 @@ bool TwitchEventSubWsClient::SubscribeAll(const std::string& sessionId)
         return false;
     }
 
-    // Capture how many subscription attempts we had before this pass (for a clean per-pass summary).
-    size_t beforeCount = 0;
-    {
-        std::lock_guard<std::mutex> lk(status_mu_);
-        beforeCount = subscriptions_.size();
-    }
+// Follow (v2) requires broadcaster_user_id and moderator_user_id, and scope moderator:read:followers.
+// For v2, Twitch expects moderator_user_id to match the user represented by the token (or a moderator),
+// otherwise subscription creation can fail.
+// https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelfollow
+const std::string tokenUid = ResolveTokenUserId();
+const std::string moderatorUid = !tokenUid.empty() ? tokenUid : broadcasterUid;
 
-    // Follow (v2) requires broadcaster_user_id and moderator_user_id, and scope moderator:read:followers.
-    // For v2, Twitch expects moderator_user_id to match the user represented by the token (or a moderator),
-    // otherwise subscription creation can fail.
-    // https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelfollow
-    const std::string tokenUid = ResolveTokenUserId();
-    const std::string moderatorUid = !tokenUid.empty() ? tokenUid : broadcasterUid;
+bool okAny = false;
+okAny |= CreateSubscription(
+    "channel.follow",
+    "2",
+    json({ {"broadcaster_user_id", broadcasterUid}, {"moderator_user_id", moderatorUid} }).dump(),
+    sessionId);
 
-    bool okAny = false;
-
-    const bool okFollow = CreateSubscription(
-        "channel.follow",
-        "2",
-        json({ {"broadcaster_user_id", broadcasterUid}, {"moderator_user_id", moderatorUid} }).dump(),
-        sessionId);
-
-    okAny |= okFollow;
-
-    if (!okFollow) {
-        // Add extra context because follow is the most common “works on my machine” failure:
-        // the token user must be the broadcaster or a moderator of the channel.
-        OutputDebug(
-            L"Follow subscription failed context: broadcaster_user_id=" + Utf8ToWide(broadcasterUid) +
-            L" token_user_id=" + Utf8ToWide(tokenUid) +
-            L" moderator_user_id(sent)=" + Utf8ToWide(moderatorUid) +
-            L" (token user must be broadcaster or moderator; scope moderator:read:followers required)");
-    }
-
-    // Subscriptions (v1) require broadcaster_user_id and scope channel:read:subscriptions.
+// Subscriptions (v1) require broadcaster_user_id and scope channel:read:subscriptions.
     // https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelsubscribe
-    const bool okSub = CreateSubscription(
+    okAny |= CreateSubscription(
         "channel.subscribe",
         "1",
         json({ {"broadcaster_user_id", broadcasterUid} }).dump(),
         sessionId);
 
-    okAny |= okSub;
-
     // Gifted subscriptions (v1) require broadcaster_user_id and scope channel:read:subscriptions.
     // https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelsubscriptiongift
-    const bool okGift = CreateSubscription(
+    okAny |= CreateSubscription(
         "channel.subscription.gift",
         "1",
         json({ {"broadcaster_user_id", broadcasterUid} }).dump(),
         sessionId);
-
-    okAny |= okGift;
-
-    // Log a short per-pass summary so you can diagnose “some events missing” instantly.
-    {
-        std::lock_guard<std::mutex> lk(status_mu_);
-        size_t afterCount = subscriptions_.size();
-        size_t added = (afterCount >= beforeCount) ? (afterCount - beforeCount) : 0;
-
-        int ok = 0, fail = 0;
-        std::wstring details;
-
-        for (size_t i = beforeCount; i < afterCount; ++i) {
-            const json& a = subscriptions_[i];
-            const bool aok = a.value("ok", false);
-            if (aok) ok++; else fail++;
-
-            std::string type = a.value("type", "");
-            int status = a.value("status", 0);
-
-            details += L"  - " + Utf8ToWide(type) +
-                       L" HTTP " + std::to_wstring(status) +
-                       (aok ? L" (ok)" : L" (fail)") + L"";
-        }
-
-        OutputDebug(L"SubscribeAll summary: attempted=" + std::to_wstring((int)added) +
-                    L" ok=" + std::to_wstring(ok) +
-                    L" fail=" + std::to_wstring(fail) + L"" + details);
-    }
 
     return okAny;
 }
@@ -1190,4 +988,5 @@ std::string TwitchEventSubWsClient::BuildHumanReadableMessage(const std::string&
     if (!msg.empty()) return "📣 " + msg;
     return "📣 Twitch event";
 }
+
 

--- a/Mode-S Client/integrations/twitch/TwitchEventSubWsClient.h
+++ b/Mode-S Client/integrations/twitch/TwitchEventSubWsClient.h
@@ -77,9 +77,6 @@ private:
     std::atomic<bool> running_{ false };
 
     // WebSocket handle so Stop() can unblock WinHttpWebSocketReceive.
-    // Lifecycle mutex: makes Start/Stop idempotent and thread-join safe.
-    std::mutex lifecycle_mu_;
-
     std::mutex ws_mu_;
     void* ws_handle_{ nullptr };
 
@@ -95,11 +92,9 @@ private:
     bool connected_ = false;
     bool subscribed_ = false;
     std::string session_id_;
-    int keepalive_timeout_sec_ = 0;
     std::int64_t last_ws_message_ms_ = 0;
     std::int64_t last_keepalive_ms_ = 0;
     std::int64_t last_helix_ok_ms_ = 0;
-    std::atomic<std::uint64_t> run_epoch_{0};
     std::string last_error_;
     nlohmann::json subscriptions_ = nlohmann::json::array();
 };

--- a/Mode-S Client/src/AppState.h
+++ b/Mode-S Client/src/AppState.h
@@ -51,6 +51,13 @@ struct EventItem {
     std::int64_t ts_ms{};
 };
 
+struct ErrorEntry {
+        std::uint64_t id{};
+        std::int64_t ts_ms{};
+        std::string msg;
+    };
+
+
 struct Metrics {
     std::int64_t ts_ms{};
     int twitch_viewers{};
@@ -97,6 +104,10 @@ public:
     void add_twitch_eventsub_event(const nlohmann::json& ev);
     nlohmann::json twitch_eventsub_events_json(int limit = 200) const;
     void clear_twitch_eventsub_events();
+
+    // Ring buffer of recent EventSub errors/warnings (for quick diagnosis).
+    void push_twitch_eventsub_error(const std::string& msg);
+    nlohmann::json twitch_eventsub_errors_json(int limit = 50) const;
 
     void push_youtube_event(const EventItem& e);
     nlohmann::json youtube_events_json(size_t limit = 200) const;
@@ -211,6 +222,7 @@ private:
     std::deque<EventItem> tiktok_events_; // last 200
     std::deque<EventItem> youtube_events_; // last 200
     std::deque<nlohmann::json> twitch_eventsub_events_; // last 200 by default
+    std::deque<ErrorEntry> twitch_eventsub_errors_; // last 200 (most recent)
 
     // --- Bot commands ---
     struct BotCmd {
@@ -243,7 +255,9 @@ std::string overlay_header_path_utf8_;
         {"last_helix_ok_ms", 0},
         {"last_error", ""},
         {"subscriptions", nlohmann::json::array()}
-    };
+    };    
+
+
 
     struct LogEntry {
         std::uint64_t id{};


### PR DESCRIPTION
## Summary
This PR implements improvements to the Twitch EventSub WebSocket client to eliminate “connected but silent” failure modes by adding a conservative **silence watchdog** and by **exposing EventSub health/status via the local HTTP API**.

- Fixes #53
- Fixes #59

## Problem
During stream, Twitch EventSub could appear **connected** but stop delivering events (subs, gifts, follows, etc.). This results in:
- No Twitch event messages injected into chat/overlay
- No alerts in overlay
- “Looks fine” connection state but **silent** behavior

## What changed

### 1) Keepalive / silence watchdog (moderate behavior change; safe thresholds)
**Goal:** If the EventSub socket stalls, it self-heals.

- Track EventSub keepalive timeout from session welcome
- Maintain timestamps for “last received message” / “last meaningful event”
- If the connection is silent beyond **2× keepalive + grace**, automatically triggers a reconnect
- Backoff/reconnect logic remains conservative to avoid reconnect loops

### 2) Expose EventSub health/status via HTTP API (low risk)
**Goal:** Visibility + confidence that the watchdog is behaving.

- AppState stores current EventSub health snapshot (connected/session id/last msg time/keepalive/last error)
- HttpServer exposes this via API endpoints (see “How to test”)

## Files touched
- `src/AppState.h`
- `src/AppState.cpp`
- `integrations/twitch/TwitchEventSubWsClient.h`
- `integrations/twitch/TwitchEventSubWsClient.cpp`
- `src/http/HttpServer.cpp`
- (If present in your branch) `src/Mode-S Client.cpp` (wiring / status propagation)

## Behavior notes / safety
- Watchdog triggers only after **2× keepalive + grace**, so normal low-traffic periods won’t cause churn.
- Reconnect is the smallest viable healing action: the app continues running and overlays recover automatically.
- Status endpoints are read-only and safe.