### PR TITLE
YouTube OAuth refresh loop on invalid_grant

### DIFF
--- a/Mode-S Client/integrations/youtube/YouTubeAuth.h
+++ b/Mode-S Client/integrations/youtube/YouTubeAuth.h
@@ -47,6 +47,10 @@ public:
     // Forces immediate refresh attempt (useful for debug endpoints).
     bool RefreshNow(std::string* out_error = nullptr);
 
+    // True when there's no usable refresh token and the user must re-authorise.
+    // (e.g. Google returns invalid_grant: "Token has been expired or revoked.")
+    bool NeedsReauth() const;
+
     // ---- Interactive OAuth (one-time login to obtain/replace refresh token) ----
     // Build the URL for the user to open in a browser.
     // If redirect_uri is empty, defaults to:


### PR DESCRIPTION
This PR fixes an issue where YouTube authentication could become permanently broken if Google revoked or expired the refresh token. When this occurred, the client would repeatedly attempt to refresh an invalid token, resulting in persistent `invalid_grant` errors and no clear recovery path.

The YouTube auth logic now correctly detects this condition, clears the stored credentials, and requires a clean re-authorisation.

Fixes issue #79.

## Changes
- Detect `invalid_grant` responses during YouTube token refresh.
- Clear stored YouTube OAuth state (access token, refresh token, expiry, scopes, channel ID) when the refresh token is invalid.
- Persist the cleared state to `config.json` to avoid repeated failed refresh attempts.
- Expose a `NeedsReauth()` helper to allow the UI/API to indicate that YouTube re-authorisation is required.
- Improve logging to clearly distinguish between transient refresh failures and permanent auth invalidation.

## Behavioural change
- If Google revokes or expires the refresh token, Mode-S will now:
  - Stop retrying the refresh loop.
  - Mark YouTube as unauthenticated.
  - Require the user to re-authorise via the OAuth flow.

This aligns YouTube OAuth behaviour with Twitch and prevents silent auth deadlocks.