### PR TITLE
Respect Twitch IRC user colours in chat overlay

### DIFF
--- a/Mode-S Client/assets/overlay/common/chat.html
+++ b/Mode-S Client/assets/overlay/common/chat.html
@@ -445,9 +445,20 @@
                 txt.appendChild(p);
             }
 
-            const userSpan = document.createElement('span');
-            userSpan.className = 'user';
-            userSpan.textContent = n.user || '';
+            const userSpan = document.createElement("span");
+            userSpan.className = "user";
+
+            const name = String(n.user || "").trim();
+            userSpan.textContent = name;
+
+            // Prefer platform/native colour if provided (Twitch IRC), otherwise fall back
+            const userColor = String(n.color || n.user_color || "").trim();
+            if (userColor && userColor.startsWith("#")) {
+                userSpan.style.color = userColor;
+            } else if (name) {
+                userSpan.style.color = colorFromName(name);
+            }
+
             txt.appendChild(userSpan);
 
             // message


### PR DESCRIPTION
Twitch usernames in the chat overlay were being rendered with platform-level CSS colours, ignoring the user-specific colour provided by Twitch IRC (`@color` tag).

The backend already parsed and forwarded this colour correctly, but the overlay UI never applied it. This change wires that final step, ensuring usernames display exactly as Twitch intends.

## What changed
- Updated `chat.html` to apply the IRC-provided user colour when rendering usernames
- Added a safe fallback to the existing deterministic colour generator for users without a defined IRC colour
- Fixed a scope error where `color` and `name` were referenced without being defined in `addLine()`

## Technical details
- Uses `n.color` / `n.user_color` from the normalized chat message
- Applies colour via inline style to correctly override platform CSS
- No backend, protocol, or data structure changes required

## Before
- All Twitch usernames rendered in a single platform colour
- Moderator / VIP / custom user colours ignored
- Colour appeared random or incorrect compared to native Twitch chat

## After
- Twitch IRC `@color` respected when present
- Users without a colour fall back to deterministic hashing
- Overlay matches native Twitch chat behaviour

## Files changed
- `chat.html`

## Fixes
- Fixes #13
