### PR TITLE
Bundle Python Sidecar Runtime for Release Builds

### DIFF
--- a/Mode-S Client/scripts/sidecar/requirements.txt
+++ b/Mode-S Client/scripts/sidecar/requirements.txt
@@ -1,0 +1,2 @@
+TikTokLive==6.6.5
+# add youtube deps later if needed

--- a/Mode-S Client/scripts/sidecar/tiktok_sidecar.py
+++ b/Mode-S Client/scripts/sidecar/tiktok_sidecar.py
@@ -12,6 +12,16 @@
 #   - We try to post it into TikTok LIVE chat (if supported by installed TikTokLive build)
 #   - We emit tiktok.send_result {ok:true/false} so C++ can log/debug
 
+# --- ensure bundled deps are importable when shipped with embedded python ---
+import os
+import sys
+from pathlib import Path as _Path
+
+_here = _Path(__file__).resolve().parent
+_bundled = _here / "site-packages"
+if _bundled.exists():
+    sys.path.insert(0, str(_bundled))
+
 import asyncio
 import json
 import sys
@@ -20,7 +30,6 @@ import traceback
 import inspect
 from pathlib import Path
 from typing import Any, Dict, Optional, Callable, Tuple
-
 
 # ---------------- stdout pipe safety (Windows) ----------------
 def emit(obj: Dict[str, Any]) -> None:

--- a/Mode-S Client/scripts/sidecar/youtube_sidecar.py
+++ b/Mode-S Client/scripts/sidecar/youtube_sidecar.py
@@ -22,6 +22,12 @@ import urllib.request
 import urllib.error
 import http.cookiejar
 
+# When shipped, dependencies live next to the sidecar in .\site-packages
+_here = Path(__file__).resolve().parent
+_bundled = _here / "site-packages"
+if _bundled.exists():
+    sys.path.insert(0, str(_bundled))
+
 POLL_INTERVAL = 15  # seconds (stats refresh)
 
 SOCS_COOKIE = "SOCS=CAESEwgDEgk0ODE3Nzk3MjQaAmVuIAEaBgiA_LyOBg"


### PR DESCRIPTION
This PR makes the TikTok and YouTube sidecars fully self‑contained in release builds by bundling an embedded Python runtime and all required Python dependencies directly into `0_release/sidecar`.

This removes any dependency on the end‑user having Python (or specific Python packages) installed and eliminates a class of runtime failures caused by environment differences.

## Background / Problem
- Sidecars (TikTok / YouTube) depend on Python libraries such as `TikTokLive`
- In development, these were resolved via the developer’s local Python environment
- In release builds, this caused failures on user machines:
  - Missing Python
  - Wrong Python version
  - Missing or incompatible dependencies
- Python embeddable builds also introduce strict path rules (`._pth`) that must be handled correctly

## What This PR Does
### 1. Bundles Python Runtime in Release Output
- Uses the official Python **embeddable** distribution
- Runtime is copied into:
  ```
  0_release/sidecar/python/
  ```

### 2. Bundles Python Dependencies
- Dependencies are installed into a temporary venv at build time
- The *flattened* `site-packages` directory is copied into:
  ```
  0_release/sidecar/site-packages/
  ```
- Uses `sysconfig.get_paths()['purelib']` to avoid nested `Lib/site-packages` layouts

### 3. Patches Embedded Python Path Configuration
- Automatically patches `python*.pth` to:
  - Preserve the standard library zip (fixes `encodings` import failure)
  - Include `..\site-packages`
  - Enable `import site`

### 4. Makes Sidecars Runtime‑Agnostic
- Both `tiktok_sidecar.py` and `youtube_sidecar.py` now:
  - Dynamically prepend bundled `site-packages` to `sys.path` when present
  - Continue to work unchanged in dev environments

### 5. Keeps Dev Workflow Unchanged
- Developers can continue using system Python / venvs
- Release builds transparently switch to the bundled runtime

## New / Updated Files
- `tools/build_release_sidecar.ps1`
- `scripts/sidecar/requirements.txt`
- `scripts/sidecar/tiktok_sidecar.py`
- `scripts/sidecar/youtube_sidecar.py`

## Release Layout After This PR
```
0_release/
  sidecar/
    python/
      python.exe
      python313.dll
      python313.zip
      python313._pth
    site-packages/
      TikTokLive/
      ...
    tiktok_sidecar.py
    youtube_sidecar.py
```

## How to Build Sidecars for Release
```powershell
cd Mode-S Client\Mode-S Client
.\tools\build_release_sidecar.ps1 -PythonEmbedDir C:\Tools\python-3.13.12-embed-amd64
```

## Validation
- `python\python.exe tiktok_sidecar.py` runs successfully from `0_release/sidecar`
- `TikTokLive` imports correctly with no system Python installed
- No regressions to dev‑time workflows

## Why This Matters
This change:
- Eliminates environment‑specific failures
- Makes releases deterministic and reproducible
- Prevents future breakage from upstream Python or TikTokLive changes
- Reduces support overhead for end users

---

**Result:** Sidecars now ship with batteries included.
Fixes #83 at the same time