### PR TITLE
Add SimBrief flight API + MSFS flightbar overlay (with mirrored border progress) + SimConnect telemetry worker

### DIFF
--- a/Mode-S Client/Mode-S Client.vcxproj
+++ b/Mode-S Client/Mode-S Client.vcxproj
@@ -143,12 +143,13 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions);CPPHTTPLIB_OPENSSL_SUPPORT</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)external;$(ProjectDir)src;$(ProjectDir)integrations;$(ProjectDir)assets;$(ProjectDir)generated;$(ProjectDir)ui</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)external;$(ProjectDir)src;$(ProjectDir)integrations;$(ProjectDir)assets;$(ProjectDir)generated;$(ProjectDir)ui;G:\MSFS 2024 SDK\SimConnect SDK\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>G:\MSFS 2024 SDK\SimConnect SDK\lib</AdditionalLibraryDirectories>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(ProjectDir)assets;$(SolutionDir)generated</AdditionalIncludeDirectories>
@@ -165,12 +166,13 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions);CPPHTTPLIB_OPENSSL_SUPPORT</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)external;$(ProjectDir)src;$(ProjectDir)integrations;$(ProjectDir)assets;$(ProjectDir)generated;$(ProjectDir)ui</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)external;$(ProjectDir)src;$(ProjectDir)integrations;$(ProjectDir)assets;$(ProjectDir)generated;$(ProjectDir)ui;G:\MSFS 2024 SDK\SimConnect SDK\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>G:\MSFS 2024 SDK\SimConnect SDK\lib</AdditionalLibraryDirectories>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(ProjectDir)assets;$(SolutionDir)generated</AdditionalIncludeDirectories>
@@ -210,6 +212,7 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="integrations\euroscope\EuroScopeIngestService.cpp" />
+    <ClCompile Include="integrations\simconnect\SimConnectWorker.cpp" />
     <ClCompile Include="integrations\obs\ObsWsClient.cpp" />
     <ClCompile Include="integrations\tiktok\TikTokFollowersService.cpp" />
     <ClCompile Include="integrations\tiktok\TikTokSidecar.cpp" />

--- a/Mode-S Client/assets/overlay/landscape/msfs_flightbar_landscape.html
+++ b/Mode-S Client/assets/overlay/landscape/msfs_flightbar_landscape.html
@@ -1,0 +1,264 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>MSFS Flight Bar (SimBrief)</title>
+  <style>
+    :root{
+      --blue:#1e6dff;
+      --panel: rgba(18,22,28,.72);
+      --stroke: rgba(255,255,255,.12);
+      --text: rgba(233,238,247,.92);
+      --muted: rgba(233,238,247,.70);
+
+      --pad: 16px;
+      --top-offset: 64px;
+      --right-reserve: 420px;
+      --radius: 18px;
+      --h: 64px;
+    }
+    html,body{width:100%;height:100%;margin:0;background:transparent;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;overflow:hidden;}
+    .bar{
+position:absolute; top:var(--top-offset); left:var(--pad); right:calc(var(--pad) + var(--right-reserve));
+      height:var(--h);
+      display:grid;
+      grid-template-columns: 1fr auto 1fr;
+      align-items:center;
+      column-gap: 12px;
+      padding:10px 12px; box-sizing:border-box;
+      border-radius:var(--radius); background:var(--panel); border:1px solid var(--stroke);
+      backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+      box-shadow: 0 18px 48px rgba(0,0,0,.35);
+      pointer-events:none; overflow:hidden;
+    }
+    
+
+    /* Progress bar (0–100%) */
+    .progWrap{
+      position:absolute;
+      left: 12px;
+      right: 12px;
+      bottom: 8px;
+      height: 4px;
+      border-radius: 999px;
+      overflow:hidden;
+      pointer-events:none;
+    }
+    .progTrack{
+      width:100%;
+      height:100%;
+      background: rgba(255,255,255,.08);
+      border: 1px solid rgba(255,255,255,.08);
+      border-radius: 999px;
+      box-sizing:border-box;
+    }
+    .progFill{
+      height:100%;
+      width:0%;
+      background: rgba(30,109,255,.95);
+      border-radius: 999px;
+      transform-origin: left center;
+      transition: width .45s ease;
+    }
+    .progLabel{
+      display:none; /* keep clean; can be enabled later */
+    }
+
+.kicker{
+      display:flex;
+      align-items:center;
+      gap:10px;
+      flex:0 0 auto;
+      min-width: 0;
+    }
+    .badge{width:8px;height:8px;border-radius:50%;background:rgba(30,109,255,.95);box-shadow:0 0 0 3px rgba(30,109,255,.18);flex:0 0 auto;}
+    .label{font-weight:650;letter-spacing:.10em;text-transform:uppercase;font-size:11px;color:var(--muted);white-space:nowrap;}
+
+    
+
+    .leftWrap{
+      display:flex;
+      align-items:center;
+      gap: 12px;
+      min-width: 0;
+    }
+.left{
+      display:flex;
+      align-items:center;
+      gap: 10px;
+      min-width: 0;
+    }
+    .callsign{font-size:22px;font-weight:850;letter-spacing:.3px;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;line-height:1;}
+    .pill{
+      align-self:center;display:inline-flex;align-items:center;gap:6px;padding:5px 10px;border-radius:999px;border:1px solid rgba(131,174,252,.28);background:rgba(131,174,252,.08);color:rgba(131,174,252,.95);font-size:10px;font-weight:800;letter-spacing:.10em;text-transform:uppercase;white-space:nowrap;flex:0 0 auto;}
+
+    .mid{
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      gap: 10px;
+      min-width: 0;
+      justify-self: center;
+    }
+    .icao{display:inline-flex;align-items:center;justify-content:center;padding:7px 11px;border-radius:14px;background:rgba(10,14,18,.35);border:1px solid rgba(255,255,255,.12);font-weight:900;letter-spacing:.16em;text-transform:uppercase;color:var(--text);min-width:70px;}
+    .arrow{color:var(--muted);font-weight:900;letter-spacing:.12em;}
+
+    .right{
+      display:flex;
+      align-items:center;
+      justify-content:flex-end;
+      gap: 10px;
+      min-width: 0;
+      justify-self: end;
+    }
+    .mini{display:flex;align-items:center;gap:8px;padding:7px 10px;border-radius:14px;background:rgba(10,14,18,.28);border:1px solid rgba(255,255,255,.10);white-space:nowrap;}
+    .mini .k{color:var(--muted);font-weight:800;letter-spacing:.10em;text-transform:uppercase;font-size:10px;}
+    .mini .v{color:var(--text);font-weight:900;font-size:13px;letter-spacing:.2px;}
+    .status{color:var(--muted);font-size:10px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:220px;}
+
+    .liveDot{width:7px;height:7px;border-radius:50%;background:rgba(30,109,255,.95);box-shadow:0 0 0 0 rgba(30,109,255,.45);animation:pulse 1.35s ease-out infinite;flex:0 0 auto;}
+    @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(30,109,255,.45);transform:scale(1)}60%{box-shadow:0 0 0 8px rgba(30,109,255,0);transform:scale(1.05)}100%{box-shadow:0 0 0 0 rgba(30,109,255,0);transform:scale(1)}}
+
+    .bump{animation:bump .22s ease-out;}
+    @keyframes bump{0%{transform:translateY(0)}45%{transform:translateY(-1px)}100%{transform:translateY(0)}}
+
+    @media (max-width:1100px){:root{--right-reserve:340px}.status{display:none}}
+    @media (max-width:860px){:root{--right-reserve:0px;--top-offset:16px}.kicker .label{display:none}}
+    @media (max-width:620px){.mid{display:none}.callsign{font-size:20px}}
+  </style>
+</head>
+<body>
+  <div class="bar" role="img" aria-label="MSFS flight bar">
+    <div class="leftWrap">
+      <div class="kicker"><span class="badge"></span><span class="label">VATSIM</span></div>
+
+      <div class="left">
+      <div class="callsign" id="callsign">—</div>
+    </div>
+      <div class="pill" id="pill">PLAN</div>
+    </div>
+
+    <div class="mid" aria-label="route">
+      <div class="icao" id="dep">----</div>
+      <div class="arrow">→</div>
+      <div class="icao" id="dest">----</div>
+    </div>
+
+    <div class="right">
+      <div class="mini"><span class="k">ALT</span><span class="v" id="alt">—</span></div>
+      <div class="mini"><span class="k">SPD</span><span class="v" id="spd">—</span></div>
+      <div class="status" id="status">Waiting for SimBrief…</div>
+    </div>
+      <div class="progWrap" aria-hidden="true">
+      <div class="progTrack"><div class="progFill" id="progFill"></div></div>
+    </div>
+  </div>
+
+<script>
+(() => {
+  const ENDPOINT = "/api/simbrief/flight";
+  const POLL_MS  = 2500;
+
+  const elCallsign = document.getElementById("callsign");
+  const elDep      = document.getElementById("dep");
+  const elDest     = document.getElementById("dest");
+  const elStatus   = document.getElementById("status");
+  const elPill     = document.getElementById("pill");
+  const elAlt      = document.getElementById("alt");
+  const elSpd      = document.getElementById("spd");
+
+
+  const elProg    = document.getElementById("progFill");
+  let smoothPct = 0;
+
+  function clamp(n, a, b){ return Math.max(a, Math.min(b, n)); }
+
+  let last = { callsign:"", dep:"", dest:"" };
+  const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+  function bump(el){ el.classList.remove("bump"); void el.offsetWidth; el.classList.add("bump"); }
+
+  function safeIcao(s){
+    const t = (typeof s === "string") ? s.trim().toUpperCase() : "";
+    return t && /^[A-Z0-9]{3,5}$/.test(t) ? t : "----";
+  }
+  function niceAge(seconds){
+    if (!(seconds >= 0)) return "";
+    if (seconds < 60) return `${Math.round(seconds)}s`;
+    const m = Math.round(seconds/60);
+    return `${m}m`;
+  }
+
+  async function poll(){
+    while(true){
+      try{
+        const r = await fetch(ENDPOINT, { cache: "no-store" });
+        if(!r.ok) throw new Error(`HTTP ${r.status}`);
+        const j = await r.json();
+
+        const ok  = j && j.ok === true;
+        const cs  = (j && typeof j.callsign === "string") ? j.callsign.trim() : "";
+        const dep = safeIcao(j && j.departure);
+        const dst = safeIcao(j && j.destination);
+        const err = (j && typeof j.error === "string") ? j.error : "";
+
+        const age = (j && typeof j.age_seconds === "number") ? j.age_seconds : null;
+        const ageTxt = age != null ? ` • age ${niceAge(age)}` : "";
+
+        if (ok){
+          elPill.textContent = "PLAN";
+          elStatus.textContent = `SimBrief loaded${ageTxt}`;
+        }else{
+          elPill.textContent = "STALE";
+          elStatus.textContent = err ? `SimBrief error: ${err}` : "SimBrief unavailable";
+        }
+
+        if (cs){
+          if (cs !== last.callsign){ elCallsign.textContent = cs; bump(elCallsign); last.callsign = cs; }
+        }else if (!last.callsign){
+          elCallsign.textContent = "—";
+        }
+
+        if (dep !== last.dep){ elDep.textContent = dep; bump(elDep); last.dep = dep; }
+        if (dst !== last.dest){ elDest.textContent = dst; bump(elDest); last.dest = dst; }
+
+        if (j && typeof j.altitude_ft === "number" && isFinite(j.altitude_ft)){
+          const a = Math.round(j.altitude_ft).toLocaleString() + "ft";
+          if (elAlt.textContent !== a){ elAlt.textContent = a; bump(elAlt); }
+        }else elAlt.textContent = "—";
+
+        if (j && typeof j.speed_kts === "number" && isFinite(j.speed_kts)){
+          const s = Math.round(j.speed_kts).toLocaleString() + "kt";
+          if (elSpd.textContent !== s){ elSpd.textContent = s; bump(elSpd); }
+        }else elSpd.textContent = "—";
+
+        // Progress bar (optional): backend can provide progress as 0..1 or progress_pct as 0..100
+        if (elProg){
+          let pct = null;
+          if (j && typeof j.progress === "number" && isFinite(j.progress)) pct = j.progress * 100.0;
+          else if (j && typeof j.progress_pct === "number" && isFinite(j.progress_pct)) pct = j.progress_pct;
+
+          if (pct == null){
+            // No progress available yet: keep at 0 but don't look "broken"
+            pct = 0;
+          }
+
+          pct = clamp(pct, 0, 100);
+
+          // simple smoothing so it glides instead of jittering
+          smoothPct = smoothPct + (pct - smoothPct) * 0.25;
+          elProg.style.width = smoothPct.toFixed(1) + "%";
+        }
+
+      }catch(e){
+        elStatus.textContent = "Waiting for SimBrief…";
+      }
+      await sleep(POLL_MS);
+    }
+  }
+  poll();
+})();
+</script>
+</body>
+</html>

--- a/Mode-S Client/integrations/simconnect/SimConnectWorker.cpp
+++ b/Mode-S Client/integrations/simconnect/SimConnectWorker.cpp
@@ -1,0 +1,225 @@
+#include "SimConnectWorker.h"
+
+#include <chrono>
+#include <cmath>
+
+// SimConnect is only needed in the .cpp
+#include <SimConnect.h>
+
+#pragma comment(lib, "SimConnect.lib")
+
+namespace simconnect {
+
+namespace {
+
+// What we ask SimConnect for (one packet).
+enum DATA_DEFINE_ID : DWORD {
+    DEF_AIRCRAFT_STATE = 1,
+};
+
+enum DATA_REQUEST_ID : DWORD {
+    REQ_AIRCRAFT_STATE = 1,
+};
+
+#pragma pack(push, 1)
+struct AircraftStateData {
+    double altitude_ft;     // PLANE ALTITUDE (feet)
+    double groundspeed_kts; // GROUND VELOCITY (knots)
+    double indicated_kts;   // AIRSPEED INDICATED (knots)
+    double lat_deg;         // PLANE LATITUDE (degrees)
+    double lon_deg;         // PLANE LONGITUDE (degrees)
+};
+#pragma pack(pop)
+
+} // namespace
+
+std::int64_t SimConnectWorker::NowUnix() {
+    // kept for compatibility if used elsewhere; returns seconds
+    using namespace std::chrono;
+    return duration_cast<seconds>(system_clock::now().time_since_epoch()).count();
+}
+
+std::int64_t SimConnectWorker::NowUnixMs() {
+    using namespace std::chrono;
+    return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+}
+
+SimConnectWorker::SimConnectWorker() = default;
+
+SimConnectWorker::~SimConnectWorker() {
+    Stop();
+}
+
+void SimConnectWorker::Start() {
+    bool expected = false;
+    if (!running_.compare_exchange_strong(expected, true)) return;
+    th_ = std::thread(&SimConnectWorker::Run, this);
+}
+
+void SimConnectWorker::Stop() {
+    if (!running_) return;
+    running_ = false;
+    if (th_.joinable()) th_.join();
+
+    // Ensure disconnected on stop
+    std::lock_guard<std::mutex> lk(mu_);
+    if (hSimConnect_) {
+        SimConnect_Close((HANDLE)hSimConnect_);
+        hSimConnect_ = nullptr;
+    }
+    SetDisconnectedLocked();
+}
+
+SimStateSnapshot SimConnectWorker::GetSnapshot() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return snap_;
+}
+
+void CALLBACK SimConnectWorker::DispatchThunk(SIMCONNECT_RECV* pData, DWORD cbData, void* pContext) {
+    auto* self = reinterpret_cast<SimConnectWorker*>(pContext);
+    if (!self) return;
+    self->HandleDispatch(pData, cbData);
+}
+
+void SimConnectWorker::SetDisconnectedLocked() {
+    snap_.connected = false;
+    snap_.has_position = false;
+    snap_.has_altitude = false;
+    snap_.has_gs = false;
+    snap_.has_ias = false;
+    // keep last numeric values (optional) but mark them as not present
+}
+
+void SimConnectWorker::HandleDispatch(SIMCONNECT_RECV* pData, DWORD /*cbData*/) {
+    if (!pData) return;
+
+    std::lock_guard<std::mutex> lk(mu_);
+
+    switch (pData->dwID) {
+    case SIMCONNECT_RECV_ID_EXCEPTION:
+        // Something went wrong; keep running but mark disconnected if needed
+        break;
+
+    case SIMCONNECT_RECV_ID_QUIT:
+        // Simulator is quitting; drop connection
+        if (hSimConnect_) {
+            SimConnect_Close((HANDLE)hSimConnect_);
+            hSimConnect_ = nullptr;
+        }
+        SetDisconnectedLocked();
+        break;
+
+    case SIMCONNECT_RECV_ID_SIMOBJECT_DATA: {
+        auto* obj = reinterpret_cast<SIMCONNECT_RECV_SIMOBJECT_DATA*>(pData);
+        if (!obj) break;
+        if (obj->dwRequestID != REQ_AIRCRAFT_STATE) break;
+
+        const auto* d = reinterpret_cast<const AircraftStateData*>(&obj->dwData);
+        if (!d) break;
+
+        snap_.connected = true;
+        snap_.has_altitude = true;
+        snap_.has_gs = true;
+        snap_.has_ias = true;
+        snap_.has_position = true;
+
+        snap_.altitude_ft = d->altitude_ft;
+        snap_.ground_speed_kts = d->groundspeed_kts;
+        snap_.indicated_airspeed_kts = d->indicated_kts;
+        snap_.lat_deg = d->lat_deg;
+        snap_.lon_deg = d->lon_deg;
+
+        snap_.ts_unix_ms = NowUnixMs();
+        snap_.last_update_unix = NowUnix();break;
+    }
+
+    default:
+        break;
+    }
+}
+
+void SimConnectWorker::Run() {
+    using namespace std::chrono;
+
+    // Retry loop: if MSFS isn't running, SimConnect_Open will fail; we wait and try again.
+    while (running_) {
+        {
+            std::lock_guard<std::mutex> lk(mu_);
+            if (hSimConnect_) {
+                // already connected; fall through to polling below
+            }
+        }
+
+        // Connect if not connected
+        {
+            std::lock_guard<std::mutex> lk(mu_);
+            if (!hSimConnect_) {
+                HANDLE h = nullptr;
+                HRESULT hr = SimConnect_Open(&h, "Mode-S Client", nullptr, 0, 0, 0);
+                if (SUCCEEDED(hr) && h) {
+                    hSimConnect_ = (void*)h;
+
+                    // Define the data we want
+                    SimConnect_AddToDataDefinition(h, DEF_AIRCRAFT_STATE, "PLANE ALTITUDE", "feet");
+                    SimConnect_AddToDataDefinition(h, DEF_AIRCRAFT_STATE, "GROUND VELOCITY", "knots");
+                    SimConnect_AddToDataDefinition(h, DEF_AIRCRAFT_STATE, "AIRSPEED INDICATED", "knots");
+                    SimConnect_AddToDataDefinition(h, DEF_AIRCRAFT_STATE, "PLANE LATITUDE", "degrees");
+                    SimConnect_AddToDataDefinition(h, DEF_AIRCRAFT_STATE, "PLANE LONGITUDE", "degrees");
+
+                    // Request updates ~2Hz (every 0.5s)
+                    SimConnect_RequestDataOnSimObject(
+                        h,
+                        REQ_AIRCRAFT_STATE,
+                        DEF_AIRCRAFT_STATE,
+                        SIMCONNECT_OBJECT_ID_USER,
+                        SIMCONNECT_PERIOD_SECOND,
+                        SIMCONNECT_DATA_REQUEST_FLAG_DEFAULT,
+                        0,  // origin
+                        0,  // interval (seconds)
+                        0   // limit
+                    );
+
+                    snap_.connected = true;
+                    snap_.ts_unix_ms = NowUnixMs();
+                    snap_.last_update_unix = NowUnix();
+                } else {
+                    // Not running yet / can't connect
+                    SetDisconnectedLocked();
+                }
+            }
+        }
+
+        // If connected, pump dispatch and sleep a bit.
+        HANDLE hLocal = nullptr;
+        {
+            std::lock_guard<std::mutex> lk(mu_);
+            hLocal = (HANDLE)hSimConnect_;
+        }
+
+        if (hLocal) {
+            // Pump callbacks
+            SimConnect_CallDispatch(hLocal, &SimConnectWorker::DispatchThunk, this);
+
+            // If we haven't had an update in a while, consider it stale/disconnected
+            {
+                std::lock_guard<std::mutex> lk(mu_);
+                if (snap_.connected) {
+                    auto age = NowUnix() - snap_.last_update_unix;
+                    if (snap_.last_update_unix != 0 && age > 5) {
+                        // keep connection handle but mark stale (MSFS paused / menus etc.)
+                        // We don't flip connected=false here, just leave it true; overlay can use age if you expose it.
+                    }
+                }
+            }
+
+            std::this_thread::sleep_for(milliseconds(200));
+        } else {
+            // Not connected; retry slower
+            std::this_thread::sleep_for(milliseconds(750));
+        }
+    }
+
+    // Cleanup on exit handled in Stop()
+}
+
+} // namespace simconnect

--- a/Mode-S Client/integrations/simconnect/SimConnectWorker.h
+++ b/Mode-S Client/integrations/simconnect/SimConnectWorker.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+
+#ifdef _WIN32
+  #include <Windows.h>
+#endif
+
+// Forward declaration so consumers don't need SimConnect.h included here.
+struct SIMCONNECT_RECV;
+
+namespace simconnect {
+
+struct SimStateSnapshot {
+    // Connection state
+    bool connected = false;
+
+    // Presence flags (what HttpServer expects)
+    bool has_position = false;
+    bool has_altitude = false;
+    bool has_gs = false;
+    bool has_ias = false;
+
+    // Values (names expected by HttpServer)
+    double lat_deg = 0.0;
+    double lon_deg = 0.0;
+
+    double altitude_ft = 0.0;              // feet
+    double ground_speed_kts = 0.0;         // knots (GS)
+    double indicated_airspeed_kts = 0.0;   // knots (IAS)
+
+    // Timestamp in milliseconds (what HttpServer expects)
+    std::int64_t ts_unix_ms = 0;
+
+
+    // Internal (seconds)
+    std::int64_t last_update_unix = 0;
+};
+
+
+
+class SimConnectWorker {
+public:
+    SimConnectWorker();
+    ~SimConnectWorker();
+
+    SimConnectWorker(const SimConnectWorker&) = delete;
+    SimConnectWorker& operator=(const SimConnectWorker&) = delete;
+
+    void Start();
+    void Stop();
+
+    SimStateSnapshot GetSnapshot() const;
+
+private:
+    // SimConnect dispatch callback must be a plain function pointer; static member works.
+    static void CALLBACK DispatchThunk(SIMCONNECT_RECV* pData, DWORD cbData, void* pContext);
+
+    void Run();
+    void HandleDispatch(SIMCONNECT_RECV* pData, DWORD cbData);
+
+    void SetDisconnectedLocked();
+    static std::int64_t NowUnix();
+    static std::int64_t NowUnixMs();
+
+private:
+    std::atomic<bool> running_{false};
+    std::thread       th_;
+
+    // Guard all snapshot + simconnect handle state.
+    mutable std::mutex mu_;
+    SimStateSnapshot   snap_;
+
+    void* hSimConnect_ = nullptr; // kept as void* here; real type is HANDLE from SimConnect.h
+};
+
+} // namespace simconnect

--- a/Mode-S Client/src/http/HttpServer.cpp
+++ b/Mode-S Client/src/http/HttpServer.cpp
@@ -15,6 +15,7 @@
 #include "../../integrations/twitch/TwitchHelixService.h"
 #include "../../integrations/twitch/TwitchAuth.h"
 #include "../../integrations/youtube/YouTubeAuth.h"
+#include "../../integrations/simconnect/SimConnectWorker.h"
 #include "../AppConfig.h"
 
 namespace {
@@ -85,6 +86,31 @@ namespace {
 
         return true;
     }
+}
+
+
+static double JsonGetDoublePath(const nlohmann::json& j, std::initializer_list<const char*> path, double fallback = 0.0, bool* out_ok = nullptr) {
+    const nlohmann::json* cur = &j;
+    for (auto* k : path) {
+        if (!cur->is_object()) { if (out_ok) *out_ok = false; return fallback; }
+        auto it = cur->find(k);
+        if (it == cur->end()) { if (out_ok) *out_ok = false; return fallback; }
+        cur = &(*it);
+    }
+    try {
+        if (cur->is_number_float() || cur->is_number_integer()) {
+            if (out_ok) *out_ok = true;
+            return cur->get<double>();
+        }
+        if (cur->is_string()) {
+            const std::string s = cur->get<std::string>();
+            if (s.empty()) { if (out_ok) *out_ok = false; return fallback; }
+            if (out_ok) *out_ok = true;
+            return std::stod(s);
+        }
+    } catch (...) {}
+    if (out_ok) *out_ok = false;
+    return fallback;
 }
 
 // --------------------------------------------------------------------------------------
@@ -259,6 +285,9 @@ void HttpServer::Start() {
     // Start SimBrief cache worker (safe even if it fails; endpoint will still respond).
     StartSimBriefWorker();
 
+    // Start SimConnect worker (safe even if MSFS isn't running; it will keep retrying).
+    StartSimConnectWorker();
+
     thread_ = std::thread([this]() {
         try {
             SafeOutputLog(log_, L"HTTP: listening on http://127.0.0.1:" + std::to_wstring(opt_.port));
@@ -274,6 +303,7 @@ void HttpServer::Stop() {
     if (!svr_) return;
 
     StopSimBriefWorker();
+    StopSimConnectWorker();
     try {
         svr_->stop();
     }
@@ -347,6 +377,27 @@ void HttpServer::StartSimBriefWorker() {
             if (dep.empty()) dep = JsonGetStringPath(raw, { "atc", "orig" });
 
             std::string dest = JsonGetStringPath(raw, { "destination", "icao_code" });
+
+            // Optional: coordinates + distance (used for progress calculations when we also have live position).
+            bool ok1=false, ok2=false, ok3=false, ok4=false, okd=false;
+            double origin_lat2 = JsonGetDoublePath(raw, { "origin", "pos_lat" }, 0.0, &ok1);
+            double origin_lon2 = JsonGetDoublePath(raw, { "origin", "pos_long" }, 0.0, &ok2);
+            double dest_lat2   = JsonGetDoublePath(raw, { "destination", "pos_lat" }, 0.0, &ok3);
+            double dest_lon2   = JsonGetDoublePath(raw, { "destination", "pos_long" }, 0.0, &ok4);
+
+            // Some exports use lat/lon keys (be tolerant).
+            if (!(ok1 && ok2)) {
+                origin_lat2 = JsonGetDoublePath(raw, { "origin", "lat" }, origin_lat2, &ok1);
+                origin_lon2 = JsonGetDoublePath(raw, { "origin", "lon" }, origin_lon2, &ok2);
+            }
+            if (!(ok3 && ok4)) {
+                dest_lat2 = JsonGetDoublePath(raw, { "destination", "lat" }, dest_lat2, &ok3);
+                dest_lon2 = JsonGetDoublePath(raw, { "destination", "lon" }, dest_lon2, &ok4);
+            }
+
+            // Planned route distance (nm) if present.
+            const double route_nm = JsonGetDoublePath(raw, { "general", "route_distance" }, 0.0, &okd);
+
             if (dest.empty()) dest = JsonGetStringPath(raw, { "atc", "dest" });
 
             std::string ofp_id = JsonGetStringPath(raw, { "general", "ofp_id" });
@@ -371,6 +422,11 @@ void HttpServer::StartSimBriefWorker() {
                 {"destination", dest},
                 {"ofp_id", ofp_id},
                 {"generated_at_unix", generated_unix},
+                {"origin_lat_deg", (ok1 && ok2) ? origin_lat2 : 0.0},
+                {"origin_lon_deg", (ok1 && ok2) ? origin_lon2 : 0.0},
+                {"dest_lat_deg",   (ok3 && ok4) ? dest_lat2   : 0.0},
+                {"dest_lon_deg",   (ok3 && ok4) ? dest_lon2   : 0.0},
+                {"route_distance_nm", okd ? route_nm : 0.0},
                 {"last_refresh_unix", now},
                 {"age_seconds", 0},
                 {"error", ""}
@@ -408,6 +464,19 @@ void HttpServer::StopSimBriefWorker() {
             simbrief_thread_.join();
         }
     }
+}
+
+
+void HttpServer::StartSimConnectWorker() {
+    if (simconnect_) return;
+    simconnect_ = std::make_unique<simconnect::SimConnectWorker>();
+    simconnect_->Start();
+}
+
+void HttpServer::StopSimConnectWorker() {
+    if (!simconnect_) return;
+    simconnect_->Stop();
+    simconnect_.reset();
 }
 
 // Inserts `insert` right after the first occurrence of `needle`.
@@ -572,10 +641,104 @@ void HttpServer::RegisterRoutes() {
         if (!out.contains("destination")) out["destination"] = "";
         if (!out.contains("pilot_id")) out["pilot_id"] = 11686;
         if (!out.contains("source")) out["source"] = "simbrief";
+        if (!out.contains("altitude_ft")) out["altitude_ft"] = 0.0;
+        if (!out.contains("speed_kts")) out["speed_kts"] = 0.0;
+        if (!out.contains("progress")) out["progress"] = 0.0;
+        if (!out.contains("progress_pct")) out["progress_pct"] = 0.0;
+
+        // --- Live sim fields (SimConnect) ---
+        if (simconnect_) {
+            const auto s = simconnect_->GetSnapshot();
+            out["sim_connected"] = s.connected;
+            if (s.has_altitude) out["altitude_ft"] = s.altitude_ft;
+            if (s.has_gs) out["speed_kts"] = s.ground_speed_kts; // overlay uses SPD
+            if (s.has_position) {
+                out["lat_deg"] = s.lat_deg;
+                out["lon_deg"] = s.lon_deg;
+            }
+
+            // Distance-based progress when we have origin/dest coords + live position.
+            const double oLat = out.value("origin_lat_deg", 0.0);
+            const double oLon = out.value("origin_lon_deg", 0.0);
+            const double dLat = out.value("dest_lat_deg", 0.0);
+            const double dLon = out.value("dest_lon_deg", 0.0);
+
+            auto haversine_nm = [](double lat1, double lon1, double lat2, double lon2) -> double {
+                constexpr double R_km = 6371.0;
+                auto deg2rad = [](double x) { return x * 3.14159265358979323846 / 180.0; };
+                const double p1 = deg2rad(lat1);
+                const double p2 = deg2rad(lat2);
+                const double dp = deg2rad(lat2 - lat1);
+                const double dl = deg2rad(lon2 - lon1);
+                const double a = std::sin(dp / 2) * std::sin(dp / 2) +
+                                 std::cos(p1) * std::cos(p2) *
+                                 std::sin(dl / 2) * std::sin(dl / 2);
+                const double c = 2.0 * std::atan2(std::sqrt(a), std::sqrt(1.0 - a));
+                const double km = R_km * c;
+                return km * 0.539956803; // km -> nm
+            };
+
+            double progress = 0.0;
+            if (s.has_position && (oLat != 0.0 || oLon != 0.0) && (dLat != 0.0 || dLon != 0.0)) {
+                const double total_nm = haversine_nm(oLat, oLon, dLat, dLon);
+                const double rem_nm   = haversine_nm(s.lat_deg, s.lon_deg, dLat, dLon);
+                if (total_nm > 1.0) {
+                    progress = 1.0 - (rem_nm / total_nm);
+                    if (progress < 0.0) progress = 0.0;
+                    if (progress > 1.0) progress = 1.0;
+                }
+            }
+
+            out["progress"] = progress;           // 0..1 (overlay supports this)
+            out["progress_pct"] = progress * 100.0;
+        } else {
+            out["sim_connected"] = false;
+        }
+
 
         res.status = 200;
         res.set_content(out.dump(2), "application/json; charset=utf-8");
     });
+
+    svr_->Get("/api/simconnect/state", [&](const httplib::Request&, httplib::Response& res) {
+        nlohmann::json out = nlohmann::json::object();
+
+        if (simconnect_) {
+            const auto s = simconnect_->GetSnapshot();
+            out["ok"] = true;
+            out["connected"] = s.connected;
+            out["ts_unix_ms"] = s.ts_unix_ms;
+
+            out["lat_deg"] = s.has_position ? s.lat_deg : 0.0;
+            out["lon_deg"] = s.has_position ? s.lon_deg : 0.0;
+
+            out["altitude_ft"] = s.has_altitude ? s.altitude_ft : 0.0;
+            out["ground_speed_kts"] = s.has_gs ? s.ground_speed_kts : 0.0;
+            out["indicated_airspeed_kts"] = s.has_ias ? s.indicated_airspeed_kts : 0.0;
+
+            out["has_position"] = s.has_position;
+            out["has_altitude"] = s.has_altitude;
+            out["has_gs"] = s.has_gs;
+            out["has_ias"] = s.has_ias;
+        } else {
+            out["ok"] = true;
+            out["connected"] = false;
+            out["ts_unix_ms"] = NowUnixSeconds() * 1000;
+            out["has_position"] = false;
+            out["has_altitude"] = false;
+            out["has_gs"] = false;
+            out["has_ias"] = false;
+            out["lat_deg"] = 0.0;
+            out["lon_deg"] = 0.0;
+            out["altitude_ft"] = 0.0;
+            out["ground_speed_kts"] = 0.0;
+            out["indicated_airspeed_kts"] = 0.0;
+        }
+
+        res.status = 200;
+        res.set_content(out.dump(2), "application/json; charset=utf-8");
+    });
+
 
     // --- API: Twitch EventSub diagnostics ---
     

--- a/Mode-S Client/src/http/HttpServer.h
+++ b/Mode-S Client/src/http/HttpServer.h
@@ -15,6 +15,8 @@
 class AppState;
 class ChatAggregator;
 class EuroScopeIngestService;
+
+namespace simconnect { class SimConnectWorker; }
 struct AppConfig;
 
 // Simple embedded HTTP server that hosts API routes and overlay static files.
@@ -78,6 +80,10 @@ private:
     void StartSimBriefWorker();
     void StopSimBriefWorker();
 
+    // --- SimConnect (live sim data) ---
+    void StartSimConnectWorker();
+    void StopSimConnectWorker();
+
     AppState& state_;
     ChatAggregator& chat_;
     EuroScopeIngestService& euroscope_;
@@ -94,6 +100,8 @@ private:
     std::int64_t simbrief_last_refresh_unix_ = 0;
     std::thread simbrief_thread_;
     std::atomic<bool> simbrief_stop_{ false };
+
+    std::unique_ptr<simconnect::SimConnectWorker> simconnect_;
 
     std::unique_ptr<httplib::Server> svr_;
     std::thread thread_;


### PR DESCRIPTION
## Summary
This PR adds an MSFS/VATSIM-focused “flight bar” overlay and the backend plumbing needed to feed it with:
- **SimBrief plan data** (callsign / departure / destination) via a new HTTP endpoint
- **SimConnect telemetry** (altitude / speed / position) via a new worker integration (auto-reconnect)
- A **flight progress border** UI treatment in the overlay (mirrored fill from mid-left to mid-right)

## Key features
- **New API endpoint:** `GET /api/simbrief/flight`
  - Fetches SimBrief OFP for pilot ID **11686**
  - Auto-refreshes in the backend every **10 minutes**
  - Returns JSON suitable for overlays (plan fields + optional live fields when available)
- **New SimConnect worker integration** under `<projectdir>/integrations/simconnect`
  - Polls and auto-reconnects if MSFS is not running
  - Captures altitude (ft), speed (kts), and position (lat/lon)
  - Exposes a snapshot struct used by the HTTP layer
- **New overlay:** MSFS/VATSIM flight bar (landscape)
  - Displays callsign + DEP → DEST + ALT/SPD + status text
  - Progress renders as a **mirrored border** that “paints” the frame:
    - starts at mid-left and advances along **top + bottom simultaneously**
    - ends at mid-right so that at 100% the border is fully blue
  - Rounded corners are arc-based and inset so the stroke sits **inside** the bar radius

## Files changed / added

### Backend
- `src/http/HttpServer.cpp`
- `src/http/HttpServer.h`
- `integrations/simbrief/*` (SimBrief fetch + cache / refresh wiring)
- `integrations/simconnect/SimConnectWorker.h` **(new)**
- `integrations/simconnect/SimConnectWorker.cpp` **(new)**
- `Mode-S Client.vcxproj` (SimConnect include/lib path or build integration, as needed)

### Overlay
- `assets/overlay/msfs_flightbar_landscape_clean.html` (final overlay file)

## API contract (overlay-facing)
### `GET /api/simbrief/flight`
Expected JSON fields used by the overlay:
- `ok` (bool)
- `error` (string, optional)
- `callsign` (string)
- `departure` (string ICAO)
- `destination` (string ICAO)
- `age_seconds` (number)
- `altitude_ft` (number, optional; from SimConnect)
- `speed_kts` (number, optional; from SimConnect)
- `progress` (number 0..1, optional) **or** `progress_pct` (number 0..100, optional)

## Build notes
### SimConnect SDK (dev build only)
Developers must install/configure the MSFS 2024 SimConnect SDK (v1.6.4) to compile:
- Add include dir: `...\SimConnect SDK\include`
- Add lib dir: `...\SimConnect SDK\lib`
- Link against `SimConnect.lib`

### Runtime DLL
End users do **not** need the SDK, but the app must be able to load `SimConnect.dll` at runtime.
For local testing, placing `SimConnect.dll` next to `Mode-S Client.exe` resolves the Windows loader error.

## Testing
### Backend
1. Start Mode-S Client
2. Verify SimBrief endpoint:
   - Open: `http://localhost:17845/api/simbrief/flight`
   - Confirm `callsign`, `departure`, `destination` populate (and `age_seconds` updates)
3. Start MSFS
4. Verify telemetry appears in endpoint payload (ALT/SPD)

### Overlay
1. Add Browser Source in OBS:
   - URL: `http://localhost:17845/assets/overlay/msfs_flightbar_landscape_clean.html`
   - Width/Height: match your canvas
2. Confirm:
   - Callsign + route appear when SimBrief is available
   - ALT/SPD appear when MSFS is running
   - Border progress animates (if `progress` or `progress_pct` is present)