### PR TITLE
Moved / consolidated helpers

### DIFF
--- a/Mode-S Client/src/Mode-S Client.cpp
+++ b/Mode-S Client/src/Mode-S Client.cpp
@@ -51,14 +51,6 @@
 // Web UI log capture: LogLine() will also push into AppState so /api/log can display it.
 static AppState* gStateForWebLog = nullptr;
 
-static std::string ToUtf8(const std::wstring& w) {
-    if (w.empty()) return "";
-    int len = WideCharToMultiByte(CP_UTF8, 0, w.c_str(), (int)w.size(), nullptr, 0, nullptr, nullptr);
-    std::string s(len, '\0');
-    WideCharToMultiByte(CP_UTF8, 0, w.c_str(), (int)w.size(), s.data(), len, nullptr, nullptr);
-    return s;
-}
-
 // --------------------------- WebView2 (Modern UI host) ----------------------
 #  if defined(__has_include)
 #    if __has_include("WebView2.h")
@@ -206,14 +198,6 @@ static void JoinWithTimeout(std::thread& t, DWORD timeoutMs, const wchar_t* name
     // Timed out (or failed). Don't hang shutdown.
     LogLine(std::wstring(L"Timeout waiting for thread: ") + name + L" (detaching)");
     t.detach(); // process exit will still terminate it if we quit main loop
-}
-
-static std::wstring ToW(const std::string& s) {
-    if (s.empty()) return L"";
-    int len = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), (int)s.size(), nullptr, 0);
-    std::wstring w(len, L'\0');
-    MultiByteToWideChar(CP_UTF8, 0, s.c_str(), (int)s.size(), w.data(), len);
-    return w;
 }
 
 struct HttpResult {

--- a/Mode-S Client/src/core/StringUtil.cpp
+++ b/Mode-S Client/src/core/StringUtil.cpp
@@ -1,6 +1,8 @@
 #include "StringUtil.h"
+#include <Windows.h>
 #include <algorithm>
 #include <cctype>
+
 
 std::string UrlEncode(const std::string& s)
 {
@@ -34,17 +36,6 @@ std::string Trim(const std::string& s)
     return s.substr(a, b - a);
 }
 
-void ReplaceAll(std::string& s, const std::string& from, const std::string& to)
-{
-    if (from.empty()) return;
-
-    size_t pos = 0;
-    while ((pos = s.find(from, pos)) != std::string::npos) {
-        s.replace(pos, from.size(), to);
-        pos += to.size();
-    }
-}
-
 std::string SanitizeTikTok(const std::string& input)
 {
     std::string s = Trim(input);
@@ -74,6 +65,24 @@ std::string SanitizeTwitchLogin(std::string s)
         [](unsigned char c) { return (char)std::tolower(c); });
 
     return s;
+}
+
+std::string ToUtf8(const std::wstring& w)
+{
+    if (w.empty()) return {};
+    int len = WideCharToMultiByte(CP_UTF8, 0, w.c_str(), (int)w.size(), nullptr, 0, nullptr, nullptr);
+    std::string out(len, '\0');
+    WideCharToMultiByte(CP_UTF8, 0, w.c_str(), (int)w.size(), out.data(), len, nullptr, nullptr);
+    return out;
+}
+
+std::wstring ToW(const std::string& s)
+{
+    if (s.empty()) return {};
+    int len = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), (int)s.size(), nullptr, 0);
+    std::wstring out(len, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, s.c_str(), (int)s.size(), out.data(), len);
+    return out;
 }
 
 static std::string ReadFileUtf8(const std::wstring& path) {
@@ -115,4 +124,15 @@ static int ParseIntOrDefault(const std::wstring& w, int def)
         return def;
     }
 
+}
+
+void ReplaceAll(std::string& s, const std::string& from, const std::string& to)
+{
+    if (from.empty()) return;
+
+    size_t pos = 0;
+    while ((pos = s.find(from, pos)) != std::string::npos) {
+        s.replace(pos, from.size(), to);
+        pos += to.size();
+    }
 }

--- a/Mode-S Client/src/core/StringUtil.h
+++ b/Mode-S Client/src/core/StringUtil.h
@@ -2,12 +2,17 @@
 
 #include <string>
 
-// Basic string helpers
 std::string Trim(const std::string& s);
-void ReplaceAll(std::string& s, const std::string& from, const std::string& to);
 std::string UrlEncode(const std::string& s);
-
-// Platform sanitizers
 std::string SanitizeTikTok(const std::string& input);
 std::string SanitizeYouTubeHandle(const std::string& input);
 std::string SanitizeTwitchLogin(std::string s);
+void ReplaceAll(std::string& s, const std::string& from, const std::string& to);
+
+std::string ReadFileUtf8(const std::wstring& path);
+std::string UrlEncodeGoogleFontFamily(std::string family);
+int ClampInt(int v, int lo, int hi);
+int ParseIntOrDefault(const std::wstring& w, int def);
+
+std::string ToUtf8(const std::wstring& w);
+std::wstring ToW(const std::string& s);


### PR DESCRIPTION
- `Trim`
- `UrlEncode`
- `SanitizeTikTok`
- `SanitizeYouTubeHandle`
- `SanitizeTwitchLogin`
- `ReplaceAll`
- `ReadFileUtf8`
- `UrlEncodeGoogleFontFamily`
- `ClampInt`
- `ParseIntOrDefault`
- `ToUtf8`
- `ToW`

This keeps `Mode-S Client.cpp` focused more clearly on startup, hosting, service wiring and shutdown.

#94 