### PR TITLE
Fix duplicate events in merged chat overlay

### DIFF
--- a/Mode-S Client/assets/app/chat.html
+++ b/Mode-S Client/assets/app/chat.html
@@ -353,6 +353,17 @@
                 return [];
             }
         }
+        async function fetchYouTubeEventsSafe() {
+            try {
+                const r = await fetch("/api/youtube/events?limit=200", { cache: "no-store" });
+                if (!r.ok) return [];
+                const j = await r.json();
+                const evs = Array.isArray(j?.events) ? j.events : [];
+                return evs;
+            } catch (_) {
+                return [];
+            }
+        }
 
         function remember(id) {
             if (!id) return false;
@@ -468,8 +479,8 @@
             const userColor = String(n.color || n.user_color || '').trim();
             if (userColor && userColor.startsWith('#')) {
                 userSpan.style.color = userColor;
-            } else if (name) {
-                const key = `${String(n.platform || '').trim()}:${name}`;
+            } else if (n.user) {
+                const key = `${String(n.platform || '').trim()}:${n.user}`;
                 userSpan.style.color = colorFromName(key);
             }
 
@@ -601,20 +612,28 @@
 
                 // Event fetch returns {count, events:[...]}
                 fetchEvents: async () => {
-                    const [tw, tt] = await Promise.all([
+                    const [tw, tt, yt] = await Promise.all([
                         fetchEventsSafe(),
-                        fetchTikTokEventsSafe()
+                        fetchTikTokEventsSafe(),
+                        fetchYouTubeEventsSafe()
                     ]);
+
                     const twEvents = (tw && tw.events) ? tw.events : (tw || []);
-                    const ttEvents = (tt && tt.events) ? tt.events : (tt || []);
-                    return { count: (twEvents.length + ttEvents.length), events: [...twEvents, ...ttEvents] };
+                    const ttEvents = Array.isArray(tt) ? tt : ((tt && tt.events) ? tt.events : []);
+                    const ytEvents = Array.isArray(yt) ? yt : ((yt && yt.events) ? yt.events : []);
+
+                    return {
+                        count: twEvents.length + ttEvents.length + ytEvents.length,
+                        events: [...twEvents, ...ttEvents, ...ytEvents]
+                    };
                 },
 
                 // Convert chat JSON into raw message items.
                 extractChatItems: (chatJson) => extractMessages(chatJson),
 
                 // Normalize chat raw item into a common shape
-                normalizeChatItem: (raw) => {
+                
+                : (raw) => {
                     const n = normalize(raw);
                     if (!n) return n;
                     return n;

--- a/Mode-S Client/assets/overlay/common/chat.html
+++ b/Mode-S Client/assets/overlay/common/chat.html
@@ -353,6 +353,17 @@
                 return [];
             }
         }
+        async function fetchYouTubeEventsSafe() {
+            try {
+                const r = await fetch("/api/youtube/events?limit=200", { cache: "no-store" });
+                if (!r.ok) return [];
+                const j = await r.json();
+                const evs = Array.isArray(j?.events) ? j.events : [];
+                return evs;
+            } catch (_) {
+                return [];
+            }
+        }
 
         function remember(id) {
             if (!id) return false;
@@ -468,8 +479,8 @@
             const userColor = String(n.color || n.user_color || '').trim();
             if (userColor && userColor.startsWith('#')) {
                 userSpan.style.color = userColor;
-            } else if (name) {
-                const key = `${String(n.platform || '').trim()}:${name}`;
+            } else if (n.user) {
+                const key = `${String(n.platform || '').trim()}:${n.user}`;
                 userSpan.style.color = colorFromName(key);
             }
 
@@ -601,20 +612,28 @@
 
                 // Event fetch returns {count, events:[...]}
                 fetchEvents: async () => {
-                    const [tw, tt] = await Promise.all([
+                    const [tw, tt, yt] = await Promise.all([
                         fetchEventsSafe(),
-                        fetchTikTokEventsSafe()
+                        fetchTikTokEventsSafe(),
+                        fetchYouTubeEventsSafe()
                     ]);
+
                     const twEvents = (tw && tw.events) ? tw.events : (tw || []);
-                    const ttEvents = (tt && tt.events) ? tt.events : (tt || []);
-                    return { count: (twEvents.length + ttEvents.length), events: [...twEvents, ...ttEvents] };
+                    const ttEvents = Array.isArray(tt) ? tt : ((tt && tt.events) ? tt.events : []);
+                    const ytEvents = Array.isArray(yt) ? yt : ((yt && yt.events) ? yt.events : []);
+
+                    return {
+                        count: twEvents.length + ttEvents.length + ytEvents.length,
+                        events: [...twEvents, ...ttEvents, ...ytEvents]
+                    };
                 },
 
                 // Convert chat JSON into raw message items.
                 extractChatItems: (chatJson) => extractMessages(chatJson),
 
                 // Normalize chat raw item into a common shape
-                normalizeChatItem: (raw) => {
+                
+                : (raw) => {
                     const n = normalize(raw);
                     if (!n) return n;
                     return n;

--- a/Mode-S Client/integrations/twitch/TwitchEventSubWsClient.cpp
+++ b/Mode-S Client/integrations/twitch/TwitchEventSubWsClient.cpp
@@ -1102,16 +1102,6 @@ void TwitchEventSubWsClient::HandleNotification(const void* payloadPtr)
 
             on_event_(evOut);
         }
-
-        // Forward EventSub events into chat as well (human-readable).
-        if (on_chat_event_) {
-            ChatMessage m{};
-            m.platform = "twitch";
-            m.user = user;
-            m.message = BuildHumanReadableMessage(subType, ev);
-            m.ts_ms = ts;
-            on_chat_event_(m);
-        }
     }
     catch (const std::exception& ex)
     {

--- a/Mode-S Client/src/platform/PlatformControl.cpp
+++ b/Mode-S Client/src/platform/PlatformControl.cpp
@@ -117,14 +117,6 @@ namespace PlatformControl {
                     e.ts_ms = (std::int64_t)(ts * 1000.0);
                 }
                 state.push_tiktok_event(e);
-
-                ChatMessage c;
-                c.platform = "tiktok";
-                c.user = e.user;
-                c.message = e.message;
-                c.ts_ms = e.ts_ms;
-                c.is_event = true;
-                chat.Add(std::move(c));
             }
             else if (type == "tiktok.chat") {
                 ChatMessage c;
@@ -224,14 +216,6 @@ namespace PlatformControl {
 
                 const int n = (std::max)(0, (std::min)(delta, 25));
                 for (int i = 0; i < n; ++i) {
-                    ChatMessage c;
-                    c.platform = "youtube";
-                    c.user = "Someone";
-                    c.message = "followed 👋";
-                    c.ts_ms = ts_ms + i;
-                    c.is_event = true;
-                    chat.Add(std::move(c));
-
                     EventItem e;
                     e.platform = "youtube";
                     e.type = "subscribe";


### PR DESCRIPTION
Fixes #114

This change fixes duplicated follow/sub/gift/event entries in the merged chat overlay.

The root cause was that platform events were being emitted down two separate paths:

- into the platform-specific event stores (`/api/twitch/eventsub/events`, `/api/tiktok/events`, `/api/youtube/events`)
- into `ChatAggregator` as synthetic chat messages

Because `chat.html` merges chat history and platform event feeds together, the same underlying event could appear twice with slightly different wording.

## What changed

### Backend

Separated real chat from synthetic platform events:

- **Twitch**: stopped forwarding EventSub notifications into `ChatAggregator`
- **TikTok**: stopped adding `tiktok.event` entries to `ChatAggregator`
- **YouTube**: stopped adding `youtube.followers_delta` synthetic events to `ChatAggregator`

The dedicated event feeds remain unchanged, so follows/subs/gifts/raids still appear in the overlay through their platform event endpoints.

### Frontend

- Added YouTube events into the merged overlay feed via `/api/youtube/events`
- Fixed a small username colour fallback bug in `chat.html` (`name` -> `n.user`)

## Result

The merged chat overlay now behaves as intended:

- real chat messages come from `/api/chat`
- Twitch/TikTok/YouTube event items come from their dedicated event endpoints
- event notifications appear once instead of being duplicated across chat + events