### PR TITLE
Restore TikTok chat handling and tidy sidecar error paths

### DIFF
--- a/Mode-S Client/assets/app/chat.html
+++ b/Mode-S Client/assets/app/chat.html
@@ -633,7 +633,7 @@
 
                 // Normalize chat raw item into a common shape
                 
-                : (raw) => {
+                normalizeChatItem: (raw) => {
                     const n = normalize(raw);
                     if (!n) return n;
                     return n;

--- a/Mode-S Client/assets/overlay/common/chat.html
+++ b/Mode-S Client/assets/overlay/common/chat.html
@@ -633,7 +633,7 @@
 
                 // Normalize chat raw item into a common shape
                 
-                : (raw) => {
+                normalizeChatItem: (raw) => {
                     const n = normalize(raw);
                     if (!n) return n;
                     return n;

--- a/Mode-S Client/scripts/sidecar/tiktok_sidecar.py
+++ b/Mode-S Client/scripts/sidecar/tiktok_sidecar.py
@@ -130,15 +130,12 @@ from TikTokLive.events import (
     ConnectEvent, DisconnectEvent, CommentEvent, FollowEvent,
     GiftEvent, LikeEvent, ShareEvent, SubscribeEvent
 )
+from TikTokLive.client.errors import UserOfflineError, WebcastBlocked200Error
 
 try:
     from TikTokLive.client.errors import SignAPIError  # type: ignore
 except Exception:
     SignAPIError = None  # type: ignore
-
-
-emit({"type": "tiktok.boot", "ts": now_ts()})
-
 
 # ---------------- helpers ----------------
 def extract_user_count(obj: Any) -> Optional[int]:
@@ -416,14 +413,30 @@ async def main_async() -> int:
     @client.on(CommentEvent)
     async def on_comment(event: CommentEvent):
         try:
+            user_info = getattr(event, "user_info", None)
+
+            user = (
+                getattr(user_info, "nick_name", None)
+                or getattr(user_info, "username", None)
+                or "unknown"
+            )
+
+            message = (
+                getattr(event, "content", None)
+                or getattr(event, "comment", None)
+                or getattr(event, "text", None)
+                or ""
+            )
+
             emit({
                 "type": "tiktok.chat",
                 "ts": now_ts(),
-                "user": event.user.nickname if event.user else "unknown",
-                "message": event.comment,
+                "user": str(user),
+                "message": str(message),
             })
-        except Exception:
-            pass
+
+        except Exception as ex:
+            log("tiktok.error", f"comment handler failed: {ex}")
 
     @client.on(FollowEvent)
     async def on_follow(event: FollowEvent):
@@ -484,6 +497,39 @@ async def main_async() -> int:
             await client.connect(fetch_room_info=True)
             emit_stats(False, 0, note="connect_returned", room_id=last_room_id)
             return 0
+
+        except UserOfflineError as e:
+            emit({
+                "type": "tiktok.info",
+                "ts": now_ts(),
+                "message": f"User is offline: {e}",
+            })
+            return 0
+
+        except WebcastBlocked200Error as e:
+            emit({
+                "type": "tiktok.error",
+                "ts": now_ts(),
+                "message": f"TikTok blocked this device/session: {e}",
+            })
+            return 3
+
+        except asyncio.CancelledError:
+            emit({
+                "type": "tiktok.info",
+                "ts": now_ts(),
+                "message": "TikTok sidecar cancelled",
+            })
+            raise
+
+        except KeyboardInterrupt:
+            emit({
+                "type": "tiktok.info",
+                "ts": now_ts(),
+                "message": "TikTok sidecar stopped",
+            })
+            return 0
+
         except Exception as e:
             if is_signer_failure(e):
                 delay = min(2.0 * attempt, 10.0) + 0.5
@@ -504,9 +550,16 @@ async def main_async() -> int:
             return 2
 
 
-def main() -> int:
-    return asyncio.run(main_async())
-
+def main():
+    try:
+        return asyncio.run(main_async())
+    except KeyboardInterrupt:
+        emit({
+            "type": "tiktok.info",
+            "ts": now_ts(),
+            "message": "TikTok sidecar stopped by user",
+        })
+        return 0
 
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
Fixes #114

## Summary

This follow-up fixes TikTok chat messages disappearing after the merged chat/event cleanup.

The root cause was in the TikTok sidecar comment handler, not the overlay or C++ routing:

- comment events were hitting a broken `event.user` path in TikTokLive
- the library was attempting to construct a user model with `nickName` instead of `nick_name`
- comment handling either failed outright or emitted empty `tiktok.chat` messages
- empty chat messages were then correctly ignored by the overlay

## What changed

### TikTok comment handling

Updated the `CommentEvent` handler in `tiktok_sidecar.py` to use the fields actually present in the payload:

- user name now comes from `event.user_info.nick_name`
- fallback user comes from `event.user_info.username`
- message text now comes from `event.content` with safe fallbacks

This avoids the broken `event.user` model path entirely and restores proper TikTok chat emission.

### Sidecar cleanup

Improved the sidecar connection and shutdown flow to behave more cleanly:

- handle `UserOfflineError` as an informational condition instead of a scary traceback
- handle Ctrl+C / shutdown more gracefully
- remove temporary TikTok comment debug code used during investigation

## Result

The TikTok sidecar now:

- emits real `tiktok.chat` messages again
- continues to emit TikTok event items separately
- exits more cleanly when offline or manually stopped

This keeps the merged chat overlay behaviour correct:

- chat stays in `/api/chat`
- event items stay in their dedicated event endpoints
- TikTok comments appear again without reintroducing duplicate event entries