### PR TITLE
Harden settings APIs and remove unsafe chat diagnostics

### DIFF
--- a/Mode-S Client/assets/app/app.js
+++ b/Mode-S Client/assets/app/app.js
@@ -175,6 +175,63 @@ async function saveSettingsFromInputs(){
   }
 }
 
+async function loadSettingsGlobalOnly() {
+    const s = await apiGet("/api/settings");
+    if (!s || s.ok !== true) throw new Error("ok=false");
+
+    const t = $("#tiktokUser"); if (t) t.value = sanitizeTikTok(s.tiktok_unique_id ?? "");
+    const tw = $("#twitchUser"); if (tw) tw.value = sanitizeTwitch(s.twitch_login ?? "");
+    const y = $("#youtubeUser"); if (y) y.value = sanitizeYouTube(s.youtube_handle ?? "");
+
+    updateAllPlatformInputUi();
+    return s;
+}
+
+function wireTikTokCookiesPage() {
+    const root = document.getElementById("tiktokCookiesPage");
+    if (!root) return;
+
+    const elSession = document.getElementById("ttSession");
+    const elSessionSS = document.getElementById("ttSessionSS");
+    const elTarget = document.getElementById("ttTarget");
+    const elSave = document.getElementById("btnSaveTikTokCookies");
+    const elStatus = document.getElementById("tiktokCookieStatus");
+
+    const setStatus = (t) => { if (elStatus) elStatus.textContent = t || ""; };
+
+    async function load() {
+        try {
+            const j = await apiGet("/api/settings/tiktok-cookies");
+            if (elSession) elSession.value = j.tiktok_sessionid || "";
+            if (elSessionSS) elSessionSS.value = j.tiktok_sessionid_ss || "";
+            if (elTarget) elTarget.value = j.tiktok_tt_target_idc || "";
+            setStatus("");
+        } catch (e) {
+            console.warn("Failed to load TikTok cookies", e);
+            setStatus("Could not load TikTok cookies.");
+        }
+    }
+
+    async function save() {
+        setStatus("Saving…");
+        try {
+            await apiPost("/api/settings/tiktok-cookies", {
+                tiktok_sessionid: elSession ? elSession.value.trim() : "",
+                tiktok_sessionid_ss: elSessionSS ? elSessionSS.value.trim() : "",
+                tiktok_tt_target_idc: elTarget ? elTarget.value.trim() : ""
+            });
+            setStatus("Saved.");
+            await load();
+        } catch (e) {
+            console.warn("Failed to save TikTok cookies", e);
+            setStatus(`Save failed (${e.message})`);
+        }
+    }
+
+    elSave?.addEventListener("click", save);
+    load();
+}
+
 function logLine(tag, msg){
   const log = $("#log");
   if (!log) return;
@@ -501,18 +558,19 @@ function wireActions(){
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
-  wireSmartBackButtons();
-  wireSettingsHubPage();
-  wireTwitchStreamInfoPage();
-  wireYouTubeAuthStatus();
-  loadYouTubeVodDraft();
-  wireTwitchOAuthPage();
-  wireOverlayTitlePage();
-  wireActions();
+    wireSmartBackButtons();
+    wireSettingsHubPage();
+    wireTwitchStreamInfoPage();
+    wireYouTubeAuthStatus();
+    loadYouTubeVodDraft();
+    wireTwitchOAuthPage();
+    wireTikTokCookiesPage();
+    wireOverlayTitlePage();
+    wireActions();
 
-  await loadSettings();
-  await pollMetrics();
-  await pollLog();
+    await loadSettings();
+    await pollMetrics();
+    await pollLog();
 
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
@@ -796,61 +854,116 @@ function wireYouTubeAuthStatus() {
 
 
 
-function wireTwitchOAuthPage(){
-  const root = document.getElementById("twitchOAuthPage");
-  if(!root) return;
+function wireTwitchOAuthPage() {
+    const root = document.getElementById("twitchOAuthPage");
+    if (!root) return;
 
-  const elScopes = document.getElementById("twitchOAuthScopes");
-  const elStart = document.getElementById("btnTwitchOAuthStart");
-  const elCopy = document.getElementById("btnTwitchOAuthCopy");
-  const elStatus = document.getElementById("twitchOAuthStatus");
+    const elScopes = document.getElementById("twitchOAuthScopes");
+    const elStart = document.getElementById("btnTwitchOAuthStart");
+    const elCopy = document.getElementById("btnTwitchOAuthCopy");
+    const elStatus = document.getElementById("twitchOAuthStatus");
 
-  const setStatus = (t)=>{ if(elStatus) elStatus.textContent = t || ""; };
+    const elLogin = document.getElementById("twitchLogin");
+    const elClientId = document.getElementById("twitchClientId");
+    const elClientSecret = document.getElementById("twitchClientSecret");
+    const elSave = document.getElementById("btnSaveTwitchSettings");
+    const elSettingsStatus = document.getElementById("twitchSettingsStatus");
 
-  async function load(){
-    try{
-      const j = await apiGet("/api/twitch/auth/info");
-      if(elScopes) elScopes.textContent = (j.scopes_readable || "").trim();
+    const setStatus = (t) => { if (elStatus) elStatus.textContent = t || ""; };
+    const setSettingsStatus = (t) => { if (elSettingsStatus) elSettingsStatus.textContent = t || ""; };
 
-      if(j.oauth_routes_wired === false){
-        setStatus("OAuth routes are not wired in this build.");
-        elStart && (elStart.disabled = true);
-        elCopy && (elCopy.disabled = true);
-        return;
-      }
+    async function loadOauthInfo() {
+        try {
+            const j = await apiGet("/api/twitch/auth/info");
+            if (elScopes) elScopes.textContent = (j.scopes_readable || "").trim();
 
-      const startUrl = j.start_url || "/auth/twitch/start";
-      const abs = `${window.location.origin}${startUrl}`;
+            if (j.oauth_routes_wired === false) {
+                setStatus("OAuth routes are not wired in this build.");
+                if (elStart) elStart.disabled = true;
+                if (elCopy) elCopy.disabled = true;
+                return;
+            }
 
-      elStart?.addEventListener("click", () => {
-        window.open(startUrl, "_blank", "noopener");
-        setStatus("Opened OAuth flow in a new tab.");
-      });
+            const startUrl = j.start_url || "/auth/twitch/start";
+            const abs = `${window.location.origin}${startUrl}`;
 
-      elCopy?.addEventListener("click", async () => {
-        try{
-          await navigator.clipboard.writeText(abs);
-          setStatus("Copied start URL.");
-        }catch(e){
-          // Fallback
-          const ta = document.createElement("textarea");
-          ta.value = abs;
-          document.body.appendChild(ta);
-          ta.select();
-          document.execCommand("copy");
-          document.body.removeChild(ta);
-          setStatus("Copied start URL.");
+            if (elStart && !elStart.dataset.wired) {
+                elStart.addEventListener("click", () => {
+                    window.open(startUrl, "_blank", "noopener");
+                    setStatus("Opened OAuth flow in a new tab.");
+                });
+                elStart.dataset.wired = "1";
+            }
+
+            if (elCopy && !elCopy.dataset.wired) {
+                elCopy.addEventListener("click", async () => {
+                    try {
+                        await navigator.clipboard.writeText(abs);
+                        setStatus("Copied start URL.");
+                    } catch (e) {
+                        const ta = document.createElement("textarea");
+                        ta.value = abs;
+                        document.body.appendChild(ta);
+                        ta.select();
+                        document.execCommand("copy");
+                        document.body.removeChild(ta);
+                        setStatus("Copied start URL.");
+                    }
+                });
+                elCopy.dataset.wired = "1";
+            }
+
+            setStatus("");
+        } catch (e) {
+            console.warn("Failed to load Twitch OAuth info", e);
+            setStatus("Could not load OAuth info.");
         }
-      });
-
-      setStatus("");
-    }catch(e){
-      console.warn("Failed to load Twitch OAuth info", e);
-      setStatus("Could not load OAuth info.");
     }
-  }
 
-  load();
+    async function loadSettings() {
+        try {
+            const s = await loadSettingsGlobalOnly();
+            logLine("settings", `loaded (${s.config_path || "unknown path"})`);
+        } catch (e) {
+            logLine("settings", `load failed (${e.message})`);
+        }
+    }
+
+    async function saveSettings() {
+        setSettingsStatus("Saving…");
+        try {
+            const payload = {
+                twitch_login: elLogin ? elLogin.value.trim() : "",
+                twitch_client_id: elClientId ? elClientId.value.trim() : ""
+            };
+
+            const secret = elClientSecret ? elClientSecret.value : "";
+            if (secret && secret.trim()) {
+                payload.twitch_client_secret = secret.trim();
+            }
+
+            await apiPost("/api/settings/twitch-oauth", payload);
+
+            if (elClientSecret) elClientSecret.value = "";
+            setSettingsStatus("Saved.");
+            await loadSettings();
+            await loadSettingsFromMainPageSafe();
+        } catch (e) {
+            console.warn("Failed to save Twitch settings", e);
+            setSettingsStatus(`Save failed (${e.message})`);
+        }
+    }
+
+    async function loadSettingsFromMainPageSafe() {
+        try {
+            await loadSettingsGlobalOnly();
+        } catch (_) { }
+    }
+
+    loadOauthInfo();
+    loadSettings();
+
+    elSave?.addEventListener("click", saveSettings);
 }
 
 

--- a/Mode-S Client/src/http/HttpServer.cpp
+++ b/Mode-S Client/src/http/HttpServer.cpp
@@ -1485,34 +1485,181 @@ svr.Get("/api/twitch/eventsub/status", [&](const httplib::Request&, httplib::Res
         svr.Post("/api/settingssave", handle_settings_save);
         svr.Post("/api/settings/save", handle_settings_save);
 
-    // --- API: settings (read) ---
-    // The /app UI calls this to populate the username fields on load.
-    // Keep the payload intentionally small (do not expose secrets by default).
-    svr.Get("/api/settings", [&](const httplib::Request&, httplib::Response& res) {
-        const std::wstring cfg_path_w = AppConfig::ConfigPath();
-        const std::string  cfg_path = WideToUtf8(cfg_path_w);
+        // --- Safety: restrict sensitive local-only routes to localhost ---
+// Even if the server is later bound to 0.0.0.0 or exposed via tunnels/port-forwarding,
+// we do NOT want remote clients to be able to modify bot commands/settings or inject test chat.
+        auto is_local_request = [](const httplib::Request& req) -> bool {
+            // cpp-httplib provides the peer address in remote_addr.
+            // Accept IPv4 loopback and IPv6 loopback.
+            if (req.remote_addr == "127.0.0.1" || req.remote_addr == "::1") return true;
+            // Some builds may report other 127/8 loopback values; allow them too.
+            if (req.remote_addr.rfind("127.", 0) == 0) return true;
+            return false;
+            };
 
-        json out;
-        out["ok"] = true;
-        out["config_path"] = cfg_path;
+        auto require_local = [&](const httplib::Request& req, httplib::Response& res) -> bool {
+            if (is_local_request(req)) return true;
 
-        // Username / channel identifiers (safe to expose)
-        out["tiktok_unique_id"] = config_.tiktok_unique_id;
-        out["twitch_login"] = config_.twitch_login;
-        out["youtube_handle"] = config_.youtube_handle;
+            SecurityHttpLog(
+                log_,
+                L"Blocked non-local request to " + ToW(req.path) + L" from " + ToW(req.remote_addr)
+            );
 
-        // Twitch secrets
-        out["twitch_client_id"] = config_.twitch_client_id;
-        out["twitch_client_secret"] = config_.twitch_client_secret;
+            res.status = 403;
+            res.set_content(R"({"ok":false,"error":"forbidden"})", "application/json; charset=utf-8");
+            return false;
+            };
 
-        // TikTok cookie/session fields
-        out["tiktok_sessionid"] = config_.tiktok_sessionid;
-        out["tiktok_sessionid_ss"] = config_.tiktok_sessionid_ss;
-        out["tiktok_tt_target_idc"] = config_.tiktok_tt_target_idc;
+        // --- API: settings (read) ---
+        // General app settings only. Do not expose secrets/cookies here.
+        svr.Get("/api/settings", [&](const httplib::Request&, httplib::Response& res) {
+            const std::wstring cfg_path_w = AppConfig::ConfigPath();
+            const std::string  cfg_path = WideToUtf8(cfg_path_w);
 
-        res.set_header("X-Config-Path", cfg_path.c_str());
-        res.set_content(out.dump(2), "application/json; charset=utf-8");
-        });
+            json out;
+            out["ok"] = true;
+            out["config_path"] = cfg_path;
+
+            // Public identifiers only
+            out["tiktok_unique_id"] = config_.tiktok_unique_id;
+            out["twitch_login"] = config_.twitch_login;
+            out["youtube_handle"] = config_.youtube_handle;
+
+            res.set_header("X-Config-Path", cfg_path.c_str());
+            res.set_content(out.dump(2), "application/json; charset=utf-8");
+            });
+
+        // --- API: Twitch OAuth settings (local only) ---
+// Used only by /app/twitch_oauth.html
+        svr.Get("/api/settings/twitch-oauth", [&](const httplib::Request& req, httplib::Response& res) {
+            if (!require_local(req, res)) return;
+
+            json out;
+            out["ok"] = true;
+            out["twitch_login"] = config_.twitch_login;
+            out["twitch_client_id"] = config_.twitch_client_id;
+            out["has_twitch_client_secret"] = !config_.twitch_client_secret.empty();
+
+            res.set_header("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+            res.set_header("Pragma", "no-cache");
+            res.set_content(out.dump(2), "application/json; charset=utf-8");
+            });
+
+        svr.Post("/api/settings/twitch-oauth", [&](const httplib::Request& req, httplib::Response& res) {
+            if (!require_local(req, res)) return;
+
+            try {
+                auto j = json::parse(req.body.empty() ? "{}" : req.body);
+
+                if (j.contains("twitch_login")) {
+                    config_.twitch_login = j.value("twitch_login", config_.twitch_login);
+                }
+                if (j.contains("twitch_client_id")) {
+                    config_.twitch_client_id = j.value("twitch_client_id", config_.twitch_client_id);
+                }
+
+                // Write-only secret: only update if caller explicitly provided a non-empty value
+                if (j.contains("twitch_client_secret")) {
+                    const std::string secret = j.value("twitch_client_secret", std::string{});
+                    if (!secret.empty()) {
+                        config_.twitch_client_secret = secret;
+                    }
+                }
+            }
+            catch (const std::exception& e) {
+                SettingsHttpLog(log_, L"Twitch OAuth settings rejected: invalid JSON: " + ToW(e.what()));
+                res.status = 400;
+                res.set_content(R"({"ok":false,"error":"invalid_json"})", "application/json; charset=utf-8");
+                return;
+            }
+            catch (...) {
+                SettingsHttpLog(log_, L"Twitch OAuth settings rejected: invalid JSON");
+                res.status = 400;
+                res.set_content(R"({"ok":false,"error":"invalid_json"})", "application/json; charset=utf-8");
+                return;
+            }
+
+            const std::wstring cfg_path_w = AppConfig::ConfigPath();
+            const std::string cfg_path = WideToUtf8(cfg_path_w);
+
+            if (!config_.Save()) {
+                SettingsHttpLog(log_, L"Twitch OAuth settings save failed for " + cfg_path_w);
+                res.status = 500;
+                res.set_content(R"({"ok":false,"error":"save_failed"})", "application/json; charset=utf-8");
+                return;
+            }
+
+            SettingsHttpLog(log_, L"Saved Twitch OAuth settings to " + cfg_path_w);
+
+            json out;
+            out["ok"] = true;
+            out["path"] = cfg_path;
+            out["has_twitch_client_secret"] = !config_.twitch_client_secret.empty();
+            res.set_content(out.dump(2), "application/json; charset=utf-8");
+            });
+
+        // --- API: TikTok cookies (local only) ---
+        // Used only by /app/tiktok_cookies.html
+        svr.Get("/api/settings/tiktok-cookies", [&](const httplib::Request& req, httplib::Response& res) {
+            if (!require_local(req, res)) return;
+
+            json out;
+            out["ok"] = true;
+            out["tiktok_sessionid"] = config_.tiktok_sessionid;
+            out["tiktok_sessionid_ss"] = config_.tiktok_sessionid_ss;
+            out["tiktok_tt_target_idc"] = config_.tiktok_tt_target_idc;
+
+            res.set_header("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+            res.set_header("Pragma", "no-cache");
+            res.set_content(out.dump(2), "application/json; charset=utf-8");
+            });
+
+        svr.Post("/api/settings/tiktok-cookies", [&](const httplib::Request& req, httplib::Response& res) {
+            if (!require_local(req, res)) return;
+
+            try {
+                auto j = json::parse(req.body.empty() ? "{}" : req.body);
+
+                if (j.contains("tiktok_sessionid")) {
+                    config_.tiktok_sessionid = j.value("tiktok_sessionid", config_.tiktok_sessionid);
+                }
+                if (j.contains("tiktok_sessionid_ss")) {
+                    config_.tiktok_sessionid_ss = j.value("tiktok_sessionid_ss", config_.tiktok_sessionid_ss);
+                }
+                if (j.contains("tiktok_tt_target_idc")) {
+                    config_.tiktok_tt_target_idc = j.value("tiktok_tt_target_idc", config_.tiktok_tt_target_idc);
+                }
+            }
+            catch (const std::exception& e) {
+                SettingsHttpLog(log_, L"TikTok cookie settings rejected: invalid JSON: " + ToW(e.what()));
+                res.status = 400;
+                res.set_content(R"({"ok":false,"error":"invalid_json"})", "application/json; charset=utf-8");
+                return;
+            }
+            catch (...) {
+                SettingsHttpLog(log_, L"TikTok cookie settings rejected: invalid JSON");
+                res.status = 400;
+                res.set_content(R"({"ok":false,"error":"invalid_json"})", "application/json; charset=utf-8");
+                return;
+            }
+
+            const std::wstring cfg_path_w = AppConfig::ConfigPath();
+            const std::string cfg_path = WideToUtf8(cfg_path_w);
+
+            if (!config_.Save()) {
+                SettingsHttpLog(log_, L"TikTok cookie settings save failed for " + cfg_path_w);
+                res.status = 500;
+                res.set_content(R"({"ok":false,"error":"save_failed"})", "application/json; charset=utf-8");
+                return;
+            }
+
+            SettingsHttpLog(log_, L"Saved TikTok cookie settings to " + cfg_path_w);
+
+            json out;
+            out["ok"] = true;
+            out["path"] = cfg_path;
+            res.set_content(out.dump(2), "application/json; charset=utf-8");
+            });
 
     // --- API: EuroScope ingest ---
 
@@ -1601,31 +1748,6 @@ svr.Get("/api/twitch/eventsub/status", [&](const httplib::Request&, httplib::Res
 
     svr.Get("/api/chat/recent", handle_chat_recent);
     svr.Get("/api/chat", handle_chat_recent);
-
-    // --- Safety: restrict bot mutation routes to localhost only ---
-    // Even if the server is later bound to 0.0.0.0 or exposed via tunnels/port-forwarding,
-    // we do NOT want remote clients to be able to modify bot commands/settings or inject test chat.
-    auto is_local_request = [](const httplib::Request& req) -> bool {
-        // cpp-httplib provides the peer address in remote_addr.
-        // Accept IPv4 loopback and IPv6 loopback.
-        if (req.remote_addr == "127.0.0.1" || req.remote_addr == "::1") return true;
-        // Some builds may report other 127/8 loopback values; allow them too.
-        if (req.remote_addr.rfind("127.", 0) == 0) return true;
-        return false;
-    };
-
-    auto require_local = [&](const httplib::Request& req, httplib::Response& res) -> bool {
-        if (is_local_request(req)) return true;
-
-        SecurityHttpLog(
-            log_,
-            L"Blocked non-local request to " + ToW(req.path) + L" from " + ToW(req.remote_addr)
-        );
-
-        res.status = 403;
-        res.set_content(R"({"ok":false,"error":"forbidden"})", "application/json; charset=utf-8");
-        return false;
-        };
 
     // --- API: bot commands ---
     // GET  /api/bot/commands  -> current command list
@@ -2092,26 +2214,6 @@ svr.Get("/api/twitch/eventsub/status", [&](const httplib::Request&, httplib::Res
         res.set_header("Pragma", "no-cache");
         res.set_content(out.dump(2), "application/json; charset=utf-8");
 });
-
-    // --- API: chat diagnostics ---
-    // Returns address of the ChatAggregator instance and current buffered count.
-    svr.Get("/api/chat/diag", [&](const httplib::Request&, httplib::Response& res) {
-        json out;
-        out["chat_ptr"] = (uint64_t)(uintptr_t)(&chat_);
-        out["count"] = (long long)chat_.Size();
-        // Include AppState chat count as well (some adapters write into AppState)
-        try {
-            auto v = state_.recent_chat();
-            out["state_count"] = (long long)v.size();
-        }
-        catch (...) {
-            out["state_count"] = 0;
-        }
-        out["ts_ms"] = (long long)std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::system_clock::now().time_since_epoch()
-        ).count();
-        res.set_content(out.dump(2), "application/json; charset=utf-8");
-        });
 
     // --- API: chat test inject (debug) ---
     // Example:


### PR DESCRIPTION
This change closes two security issues by tightening what the local web UI can read from the backend:

- fixes #109 by stopping `/api/settings` from exposing sensitive values
- fixes #110 by removing `/api/chat/diag`, which exposed an internal memory address

## What changed

### `/api/settings` is now public-only
The general settings endpoint now returns only the non-sensitive values the main app UI actually needs:

- `config_path`
- `tiktok_unique_id`
- `twitch_login`
- `youtube_handle`

It no longer returns:

- `twitch_client_secret`
- TikTok cookie/session values
- other sensitive credential fields

### Added dedicated settings endpoints for credential pages
To avoid breaking the dedicated management pages while still securing the general settings response, credential handling was split out into local-only endpoints:

- `GET/POST /api/settings/twitch-oauth`
- `GET/POST /api/settings/tiktok-cookies`

This keeps the settings hub lightweight while still allowing the relevant pages to load and save their own data.

### Twitch secret is now treated as write-only in the UI flow
The Twitch OAuth settings page now loads:

- `twitch_login`
- `twitch_client_id`
- whether a secret already exists

It does **not** send the stored client secret back to the browser.  
If the secret field is left blank on save, the existing secret is preserved.

### Removed `/api/chat/diag`
The unused diagnostics endpoint was removed entirely. It previously exposed a raw internal pointer value, which served no UI purpose and leaked process-internal detail.

### Local-only protection reused for sensitive routes
The existing localhost-only guard was moved so it can protect the new Twitch/TikTok credential endpoints as well as the existing local-only routes.

## Why

Previously, `/api/settings` acted as a convenient full-config response, but that meant sensitive values were exposed to any page that could call it. Splitting public settings from credential management keeps the current UI working while reducing unnecessary exposure.

Removing `/api/chat/diag` also eliminates an endpoint that leaked internals without providing meaningful value.

## Testing

- Verified `/api/settings` still loads the main settings page correctly
- Verified Twitch OAuth page can load and save via `/api/settings/twitch-oauth`
- Verified TikTok cookies page can load and save via `/api/settings/tiktok-cookies`
- Verified Twitch client secret is no longer returned in normal settings reads
- Verified `/api/chat/diag` is no longer available
- Verified sensitive credential endpoints are restricted to localhost

## Issues

Fixes #109  
Fixes #110