### PR TITLE
Move app log into Diagnostics and polish the home/dashboard layout

### DIFF
--- a/Mode-S Client/assets/app/app.css
+++ b/Mode-S Client/assets/app/app.css
@@ -439,3 +439,369 @@ background: rgba(59,130,246,.18);
   border-color: rgba(239,68,68,.65);
   box-shadow: 0 0 0 3px rgba(239,68,68,.12);
 }
+
+
+/* ------------------------------
+   Home / linked accounts refresh
+--------------------------------- */
+.home-platforms{
+  padding:0;
+}
+
+.home-platforms__head{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:16px;
+}
+
+.home-platforms__summary{
+  display:flex;
+  gap:10px;
+  flex-wrap:wrap;
+}
+
+.home-kpi{
+  min-width:132px;
+  padding:10px 12px;
+  border-radius:14px;
+  border:1px solid rgba(255,255,255,.08);
+  background:rgba(255,255,255,.03);
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+
+.home-kpi__k{
+  font-size:12px;
+  color:var(--muted2);
+}
+
+.home-kpi__v{
+  font-weight:800;
+  font-size:16px;
+}
+
+.platforms--home{
+  padding:16px;
+  gap:16px;
+}
+
+.platform--home{
+  background:linear-gradient(180deg, rgba(17,26,54,.78), rgba(17,26,54,.58));
+  border-color:rgba(255,255,255,.09);
+  box-shadow:0 14px 34px rgba(0,0,0,.20);
+}
+
+.platform--home .platform__head{
+  padding:14px 14px 12px;
+}
+
+.platform__identity{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  min-width:0;
+}
+
+.platform__statusline{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  margin-top:4px;
+}
+
+.platform__state-dot{
+  width:9px;
+  height:9px;
+  border-radius:999px;
+  background:#64748b;
+  box-shadow:0 0 0 4px rgba(100,116,139,.14);
+  flex:0 0 auto;
+}
+
+.platform--connected .platform__state-dot{
+  background:#60a5fa;
+  box-shadow:0 0 0 4px rgba(96,165,250,.14);
+}
+
+.platform--live .platform__state-dot{
+  background:var(--green);
+  box-shadow:0 0 0 4px rgba(34,197,94,.16);
+}
+
+.platform--disconnected .platform__state-dot{
+  background:#64748b;
+}
+
+.platform--home .platform__body{
+  padding:14px;
+}
+
+.platform__section-label{
+  font-size:11px;
+  letter-spacing:.12em;
+  text-transform:uppercase;
+  color:var(--muted2);
+  font-weight:800;
+  margin-bottom:10px;
+}
+
+.field--account{
+  padding:12px;
+  border-radius:14px;
+  border:1px solid rgba(255,255,255,.08);
+  background:rgba(255,255,255,.03);
+}
+
+.field__row--account{
+  align-items:stretch;
+}
+
+.field__row--account .input{
+  min-width:0;
+}
+
+.field__row--account .btn{
+  white-space:nowrap;
+  min-width:84px;
+}
+
+.platform__actions .btn{
+  flex:1 1 0;
+}
+
+.home-strip{
+  display:grid;
+  grid-template-columns:repeat(2, minmax(0,1fr));
+  gap:12px;
+  padding:0 16px 16px;
+}
+
+.home-strip__item{
+  display:flex;
+  align-items:flex-start;
+  gap:10px;
+  padding:12px 14px;
+  border-radius:14px;
+  border:1px solid rgba(255,255,255,.08);
+  background:rgba(255,255,255,.025);
+  color:var(--muted);
+  font-size:13px;
+  line-height:1.45;
+}
+
+.home-strip__dot{
+  width:10px;
+  height:10px;
+  border-radius:999px;
+  background:#f0bf63;
+  box-shadow:0 0 0 4px rgba(240,191,99,.12);
+  margin-top:4px;
+  flex:0 0 auto;
+}
+
+.home-strip__dot--blue{
+  background:#60a5fa;
+  box-shadow:0 0 0 4px rgba(96,165,250,.12);
+}
+
+.home-strip__text{
+  color:var(--muted);
+}
+
+@media (max-width: 1100px){
+  .home-platforms__head{
+    flex-direction:column;
+    align-items:stretch;
+  }
+
+  .home-platforms__summary{
+    width:100%;
+  }
+
+  .home-strip{
+    grid-template-columns:1fr;
+  }
+}
+
+@media (max-width: 700px){
+  .field__row--account{
+    flex-direction:column;
+  }
+
+  .field__row--account .btn{
+    width:100%;
+  }
+
+  .home-kpi{
+    min-width:unset;
+    flex:1 1 0;
+  }
+}
+
+
+/* ------------------------------
+   Home metrics band
+--------------------------------- */
+#topMetrics{
+  width:min(980px, calc(100% - 72px));
+  margin:16px auto 20px;
+  padding:10px;
+  display:grid;
+  grid-template-columns:repeat(4, minmax(0, 1fr));
+  gap:10px;
+  align-items:stretch;
+  border:1px solid rgba(96,165,250,.18);
+  border-radius:24px;
+  background:
+    radial-gradient(120% 180% at 50% -25%, rgba(96,165,250,.18), rgba(96,165,250,0) 48%),
+    linear-gradient(180deg, rgba(15,23,48,.76), rgba(17,26,54,.62));
+  box-shadow:
+    0 18px 42px rgba(2,8,23,.18),
+    inset 0 1px 0 rgba(255,255,255,.04);
+}
+
+#topMetrics .pill{
+  min-width:0;
+  min-height:94px;
+  padding:16px 18px;
+  gap:10px;
+  border:1px solid rgba(255,255,255,.06);
+  border-radius:18px;
+  background:linear-gradient(180deg, rgba(255,255,255,.04), rgba(255,255,255,.02));
+  justify-content:center;
+  position:relative;
+  overflow:hidden;
+  flex-direction:column;
+  align-items:flex-start;
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.03);
+}
+
+#topMetrics .pill::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:linear-gradient(135deg, rgba(255,255,255,.06), rgba(255,255,255,0) 52%);
+  opacity:.5;
+  pointer-events:none;
+}
+
+#topMetrics .pill__k,
+#topMetrics .pill__v{
+  position:relative;
+  z-index:1;
+}
+
+#topMetrics .pill__k{
+  display:block;
+  font-size:12px;
+  font-weight:700;
+  letter-spacing:.04em;
+  text-transform:uppercase;
+  color:rgba(226,232,240,.62);
+}
+
+#topMetrics .pill__v{
+  display:block;
+  font-size:34px;
+  font-weight:900;
+  line-height:1;
+  letter-spacing:-.03em;
+  color:#fff;
+}
+
+#topMetrics .pill:nth-child(1) .pill__v,
+#topMetrics .pill:nth-child(2) .pill__v,
+#topMetrics .pill:nth-child(4) .pill__v{
+  font-variant-numeric:tabular-nums;
+}
+
+#topMetrics .pill:nth-child(1){
+  background:linear-gradient(180deg, rgba(59,130,246,.11), rgba(255,255,255,.02));
+}
+
+#topMetrics .pill:nth-child(2){
+  background:linear-gradient(180deg, rgba(96,165,250,.10), rgba(255,255,255,.02));
+}
+
+#topMetrics .pill:nth-child(4){
+  background:linear-gradient(180deg, rgba(37,99,235,.10), rgba(255,255,255,.02));
+}
+
+#topMetrics .pill--status{
+  display:grid;
+  grid-template-columns:auto 1fr;
+  grid-template-rows:auto 1fr;
+  align-content:center;
+  gap:8px 10px;
+}
+
+#topMetrics .pill--status .dot{
+  grid-column:1;
+  grid-row:1;
+  align-self:center;
+  justify-self:start;
+  width:10px;
+  height:10px;
+  margin:0;
+  box-shadow:0 0 0 4px rgba(100,116,139,.16);
+  flex:0 0 auto;
+}
+
+#topMetrics .pill--status .pill__k{
+  grid-column:2;
+  grid-row:1;
+  display:block;
+  margin:0;
+}
+
+#topMetrics .pill--status .pill__v{
+  grid-column:1 / span 2;
+  grid-row:2;
+  font-size:28px;
+}
+
+@media (max-width: 1100px){
+  #topMetrics{
+    width:100%;
+    margin:14px 0 18px;
+  }
+}
+
+@media (max-width: 760px){
+  #topMetrics{
+    grid-template-columns:repeat(2, minmax(0, 1fr));
+    gap:8px;
+    padding:8px;
+    border-radius:20px;
+  }
+
+  #topMetrics .pill{
+    min-height:84px;
+    padding:14px 16px;
+    border-radius:16px;
+  }
+
+  #topMetrics .pill__v{
+    font-size:28px;
+  }
+
+  #topMetrics .pill--status .pill__v{
+    font-size:24px;
+  }
+}
+
+@media (max-width: 520px){
+  #topMetrics{
+    grid-template-columns:1fr;
+  }
+
+  #topMetrics .pill{
+    min-height:76px;
+  }
+
+  #topMetrics .pill__v{
+    font-size:24px;
+  }
+}

--- a/Mode-S Client/assets/app/app.js
+++ b/Mode-S Client/assets/app/app.js
@@ -94,6 +94,7 @@ function updatePlatformInputUi(platform){
 
 function updateAllPlatformInputUi(){
   ["tiktok", "twitch", "youtube"].forEach(updatePlatformInputUi);
+  updateHomeSummary();
 }
 
 function setActionBusy(button, busy, busyText){
@@ -254,9 +255,43 @@ function setBadge(platform, live, label){
   if (card) card.classList.toggle("platform--live", !!live);
 }
 
+function updateHomeSummary(){
+  const cards = $$(".platform[data-platform]");
+  const linked = cards.filter(card => {
+    const platform = card.dataset.platform;
+    const input = getPlatformInput(platform);
+    return !!sanitizePlatformValue(platform, input?.value || "");
+  }).length;
+  const live = cards.filter(card => card.classList.contains("platform--live")).length;
+
+  setText("linkedAccountsCount", `${linked} / ${cards.length || 0}`);
+  setText("livePlatformsCount", String(live));
+}
+
 function setState(platform, text){
   const el = document.getElementById(`${platform}State`);
   if (el) el.textContent = text;
+
+  const dot = document.getElementById(`${platform}StateDot`);
+  const card = document.querySelector(`.platform[data-platform="${platform}"]`);
+  if (!card) {
+    updateHomeSummary();
+    return;
+  }
+
+  const normalized = String(text || "").toLowerCase();
+  const live = normalized === "live";
+  const connected = live || normalized === "connected";
+
+  card.classList.toggle("platform--live", live);
+  card.classList.toggle("platform--connected", connected);
+  card.classList.toggle("platform--disconnected", !connected);
+
+  if (dot) {
+    dot.classList.toggle("platform__state-dot--live", live);
+  }
+
+  updateHomeSummary();
 }
 
 function setStopEnabled(platform, enabled){
@@ -443,6 +478,10 @@ function wireActions(){
 
   $("#btnOpenSettings")?.addEventListener("click", () => {
     window.location.href = "/app/settings.html";
+  });
+
+  $("#btnOpenDiagnostics")?.addEventListener("click", () => {
+    window.location.href = "/app/diagnostics.html";
   });
 
   $("#btnOpenBot")?.addEventListener("click", () => {

--- a/Mode-S Client/assets/app/diagnostics.html
+++ b/Mode-S Client/assets/app/diagnostics.html
@@ -5,6 +5,63 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Diagnostics — RadarController</title>
   <link rel="stylesheet" href="/app/app.css" />
+  <style>
+    html,body{height:100%;overflow:hidden}
+    body{margin:0}
+    .app{height:100vh;overflow:hidden;display:grid;grid-template-rows:auto minmax(0,1fr) auto}
+    main.grid.grid--single{min-height:0;overflow:hidden}
+    .diag-shell{display:grid;grid-template-rows:auto auto minmax(0,1fr);gap:14px;min-height:0;height:100%}
+    .diag-toolbar,.diag-summary,.diag-layout{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.08);border-radius:18px}
+    .diag-toolbar{padding:14px;display:grid;grid-template-columns:minmax(180px,1.3fr) auto auto auto auto auto;gap:10px;align-items:center}
+    .diag-search{width:100%;min-width:0}
+    .diag-chipbar{display:flex;gap:8px;flex-wrap:wrap}
+    .diag-chip{border:1px solid rgba(255,255,255,.10);background:rgba(255,255,255,.04);color:#dbe7ff;border-radius:999px;padding:8px 12px;font:inherit;cursor:pointer}
+    .diag-chip.is-active{background:linear-gradient(180deg,rgba(79,127,255,.42),rgba(53,93,199,.55));border-color:rgba(111,154,255,.55);box-shadow:0 0 0 1px rgba(255,255,255,.04) inset}
+    .diag-summary{padding:10px 14px;display:flex;gap:18px;flex-wrap:wrap;align-items:center}
+    .diag-stat{display:flex;align-items:center;gap:8px;color:#dce5ff}
+    .diag-stat__dot{width:10px;height:10px;border-radius:999px;background:#70a0ff;box-shadow:0 0 12px rgba(112,160,255,.45)}
+    .diag-stat__dot--warn{background:#f0bf63;box-shadow:0 0 12px rgba(240,191,99,.45)}
+    .diag-stat__dot--error{background:#ff6c80;box-shadow:0 0 12px rgba(255,108,128,.45)}
+    .diag-layout{padding:0;display:grid;grid-template-columns:minmax(0,1.85fr) minmax(300px,.95fr);min-height:0;height:100%;overflow:hidden}
+    .diag-listPane{border-right:1px solid rgba(255,255,255,.08);display:grid;grid-template-rows:auto minmax(0,1fr) auto;min-width:0;min-height:0}
+    .diag-header{display:grid;grid-template-columns:120px 120px 1fr 34px;gap:12px;padding:12px 16px;background:rgba(255,255,255,.03);border-bottom:1px solid rgba(255,255,255,.08);font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:#98a8d7}
+    .diag-list{overflow:auto;min-height:0;overscroll-behavior:contain}
+    .diag-row{display:grid;grid-template-columns:120px 120px 1fr 34px;gap:12px;align-items:center;padding:11px 16px;border-bottom:1px solid rgba(255,255,255,.06);cursor:pointer;transition:background .15s ease, border-color .15s ease}
+    .diag-row:hover{background:rgba(255,255,255,.035)}
+    .diag-row.is-selected{background:linear-gradient(90deg,rgba(72,114,255,.16),rgba(72,114,255,.07));box-shadow:inset 2px 0 0 rgba(96,140,255,.95)}
+    .diag-time{font-family:ui-monospace,SFMono-Regular,Consolas,monospace;color:#d6def7;white-space:nowrap}
+    .diag-source{display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:6px 10px;border-radius:999px;font-size:12px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;border:1px solid rgba(255,255,255,.12);width:max-content;max-width:100%}
+    .diag-source--HTTP{background:rgba(91,131,255,.18);color:#c9dcff}
+    .diag-source--TWITCH{background:rgba(158,96,255,.18);color:#ead8ff}
+    .diag-source--TWITCHAUTH{background:rgba(119,110,255,.18);color:#ddd8ff}
+    .diag-source--TIKTOK{background:rgba(64,196,196,.18);color:#d8ffff}
+    .diag-source--YOUTUBE{background:rgba(255,91,122,.18);color:#ffdbe3}
+    .diag-source--CONFIG,.diag-source--SYSTEM,.diag-source--MODE-S{background:rgba(255,255,255,.09);color:#eef2ff}
+    .diag-msg{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#f3f6ff}
+    .diag-msg b{font-weight:700}
+    .diag-sev{width:10px;height:10px;border-radius:999px;justify-self:center;background:#6f88c9;box-shadow:0 0 10px rgba(111,136,201,.35)}
+    .diag-sev--warn{background:#f0bf63;box-shadow:0 0 10px rgba(240,191,99,.45)}
+    .diag-sev--error{background:#ff6c80;box-shadow:0 0 10px rgba(255,108,128,.55)}
+    .diag-sev--success{background:#59d38c;box-shadow:0 0 10px rgba(89,211,140,.45)}
+    .diag-footer{display:flex;justify-content:space-between;gap:12px;padding:12px 16px;border-top:1px solid rgba(255,255,255,.08);font-size:13px;color:#aab7db}
+    .diag-detail{display:grid;grid-template-rows:auto minmax(0,1fr);min-width:0;min-height:0;overflow:hidden}
+    .diag-detail__head{padding:18px 18px 12px;border-bottom:1px solid rgba(255,255,255,.08)}
+    .diag-detail__title{font-size:24px;font-weight:800;line-height:1.1;margin-bottom:6px}
+    .diag-detail__meta{color:#b4c2e8;display:grid;gap:6px}
+    .diag-detail__body{padding:18px;display:grid;gap:16px;align-content:start;min-width:0;min-height:0;overflow:hidden}
+    .diag-panel{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.08);border-radius:16px;padding:14px}
+    .diag-panel__k{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:#98a8d7;margin-bottom:8px}
+    .diag-panel__v{color:#f3f6ff;line-height:1.5;white-space:normal;overflow-wrap:anywhere;word-break:break-word;max-width:100%}
+    .diag-raw{font-family:ui-monospace,SFMono-Regular,Consolas,monospace;font-size:13px;line-height:1.6;color:#dce6ff;white-space:pre-wrap;overflow-wrap:anywhere;word-break:break-word;max-width:100%;max-height:320px;overflow:auto}
+    .diag-empty{padding:32px 18px;color:#9eb0df}
+    .diag-toggle{display:inline-flex;align-items:center;gap:8px;padding:0 12px}
+    .diag-toggle input{accent-color:#4f7fff}
+    @media (max-width: 1180px){
+      .diag-toolbar{grid-template-columns:1fr 1fr;}
+      .diag-layout{grid-template-columns:1fr;}
+      .diag-listPane{border-right:none;border-bottom:1px solid rgba(255,255,255,.08)}
+    }
+  </style>
 </head>
 <body>
   <div class="app" id="diagnosticsPage">
@@ -22,19 +79,63 @@
       </div>
 
       <div class="topbar__actions">
-        <button class="btn btn--ghost" id="btnBackHome">Back</button>
-        <button class="btn btn--ghost" id="btnClearDiagLog">Clear</button>
+        <button class="btn btn--ghost" id="btnBackHome" type="button">Back</button>
+        <button class="btn btn--ghost" id="btnPrettyToggle" type="button">Raw</button>
+        <button class="btn btn--ghost" id="btnCopySelected" type="button">Copy Entry</button>
+        <button class="btn btn--primary" id="btnCopyDiagLog" type="button">Copy Log</button>
       </div>
     </header>
 
     <main class="grid grid--single">
-      <section class="card">
-        <div class="card__head">
-          <div class="card__title">Log</div>
-          <div class="card__hint">Verbose operational messages from the client (raw).</div>
-        </div>
-        <div class="log" id="diagLog"></div>
-      </section>
+      <div class="diag-shell">
+        <section class="diag-toolbar">
+          <input class="input diag-search" id="diagSearch" type="search" placeholder="Search logs" />
+          <div class="diag-chipbar" id="diagSourceFilter"></div>
+          <label class="diag-toggle"><input type="checkbox" id="diagImportantOnly" /> Important only</label>
+          <label class="diag-toggle"><input type="checkbox" id="diagAutoScroll" checked /> Auto-scroll</label>
+          <button class="btn btn--ghost" id="btnClearDiagLog" type="button">Clear View</button>
+          <div class="pill"><span class="pill__k">Visible</span><span class="pill__v" id="diagVisibleCount">0</span></div>
+        </section>
+
+        <section class="diag-summary">
+          <div class="diag-stat"><span class="diag-stat__dot diag-stat__dot--error"></span><span>Last error:</span><strong id="diagLastError">None</strong></div>
+          <div class="diag-stat"><span class="diag-stat__dot"></span><span>Sources:</span><strong id="diagSourceCount">0</strong></div>
+          <div class="diag-stat"><span class="diag-stat__dot diag-stat__dot--warn"></span><span>Lines loaded:</span><strong id="diagLoadedCount">0</strong></div>
+        </section>
+
+        <section class="diag-layout">
+          <div class="diag-listPane">
+            <div class="diag-header">
+              <div>Time</div>
+              <div>Source</div>
+              <div>Message</div>
+              <div></div>
+            </div>
+            <div class="diag-list" id="diagList"></div>
+            <div class="diag-footer">
+              <div id="diagFooterLeft">Waiting for log data…</div>
+              <div id="diagFooterRight">Pretty view</div>
+            </div>
+          </div>
+
+          <aside class="diag-detail">
+            <div class="diag-detail__head">
+              <div class="diag-detail__title" id="diagDetailTitle">No entry selected</div>
+              <div class="diag-detail__meta" id="diagDetailMeta">Pick a row on the left to inspect it properly.</div>
+            </div>
+            <div class="diag-detail__body">
+              <div class="diag-panel">
+                <div class="diag-panel__k">Message</div>
+                <div class="diag-panel__v" id="diagDetailMessage">Nothing selected yet.</div>
+              </div>
+              <div class="diag-panel">
+                <div class="diag-panel__k">Raw details</div>
+                <div class="diag-raw" id="diagDetailRaw">{ }</div>
+              </div>
+            </div>
+          </aside>
+        </section>
+      </div>
     </main>
 
     <footer class="footer">
@@ -44,5 +145,270 @@
   </div>
 
   <script src="/app/app.js"></script>
+  <script>
+    (() => {
+      const state = {
+        all: [],
+        visible: [],
+        source: 'ALL',
+        search: '',
+        importantOnly: false,
+        pretty: true,
+        selectedId: null,
+        clearView: false,
+      };
+
+      const el = {
+        list: document.getElementById('diagList'),
+        search: document.getElementById('diagSearch'),
+        sourceFilter: document.getElementById('diagSourceFilter'),
+        importantOnly: document.getElementById('diagImportantOnly'),
+        autoScroll: document.getElementById('diagAutoScroll'),
+        visibleCount: document.getElementById('diagVisibleCount'),
+        sourceCount: document.getElementById('diagSourceCount'),
+        loadedCount: document.getElementById('diagLoadedCount'),
+        lastError: document.getElementById('diagLastError'),
+        footerLeft: document.getElementById('diagFooterLeft'),
+        footerRight: document.getElementById('diagFooterRight'),
+        detailTitle: document.getElementById('diagDetailTitle'),
+        detailMeta: document.getElementById('diagDetailMeta'),
+        detailMessage: document.getElementById('diagDetailMessage'),
+        detailRaw: document.getElementById('diagDetailRaw'),
+        btnPretty: document.getElementById('btnPrettyToggle'),
+        btnCopyLog: document.getElementById('btnCopyDiagLog'),
+        btnCopySelected: document.getElementById('btnCopySelected'),
+        btnClear: document.getElementById('btnClearDiagLog'),
+        btnBack: document.getElementById('btnBackHome'),
+      };
+
+      const sourcePriority = ['ALL','HTTP','TWITCH','TWITCHAUTH','TIKTOK','YOUTUBE','CONFIG','MODE-S','SYSTEM','OTHER'];
+
+      function escapeHtml(s){
+        return String(s ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+      }
+
+      function tryParseJsonLine(line){
+        try { return JSON.parse(line); } catch { return null; }
+      }
+
+      function splitConcatenatedJson(text){
+        const out = [];
+        let depth = 0, inString = false, esc = false, start = -1;
+        for(let i=0;i<text.length;i++){
+          const ch = text[i];
+          if (inString){
+            if (esc) esc = false;
+            else if (ch === '\\') esc = true;
+            else if (ch === '"') inString = false;
+            continue;
+          }
+          if (ch === '"'){ inString = true; continue; }
+          if (ch === '{'){
+            if (depth === 0) start = i;
+            depth++;
+          } else if (ch === '}'){
+            depth--;
+            if (depth === 0 && start !== -1){
+              out.push(text.slice(start, i + 1));
+              start = -1;
+            }
+          }
+        }
+        return out;
+      }
+
+      function normalizePayload(data){
+        if (Array.isArray(data)) return data;
+        if (data && Array.isArray(data.entries)) return data.entries;
+        if (data && Array.isArray(data.lines)) return data.lines;
+        if (data && Array.isArray(data.log)) return data.log;
+        if (typeof data === 'string') return textToEntries(data);
+        if (data && typeof data === 'object') return [data];
+        return [];
+      }
+
+      function textToEntries(text){
+        const trimmed = String(text || '').trim();
+        if (!trimmed) return [];
+        const compact = splitConcatenatedJson(trimmed);
+        if (compact.length) return compact.map(x => tryParseJsonLine(x) || { msg: x });
+        return trimmed.split(/\r?\n/).filter(Boolean).map(line => tryParseJsonLine(line) || { msg: line });
+      }
+
+      function inferSource(msg){
+        const upper = String(msg || '').toUpperCase();
+        const keys = ['TWITCHAUTH','TWITCH','TIKTOK','YOUTUBE','HTTP','CONFIG','MODE-S','SYSTEM'];
+        for (const key of keys){
+          if (upper.includes(key + ':') || upper.startsWith(key) || upper.includes('[' + key + ']')) return key;
+        }
+        return 'OTHER';
+      }
+
+      function cleanMessage(msg, source){
+        let s = String(msg || '').trim();
+        if (source && source !== 'OTHER'){
+          s = s.replace(new RegExp('^' + source.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&') + '\s*:\s*', 'i'), '');
+          s = s.replace(new RegExp('^\\[' + source.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&') + '\]\s*', 'i'), '');
+        }
+        return s;
+      }
+
+      function inferSeverity(msg){
+        const s = String(msg || '').toLowerCase();
+        if (/(error|failed|cannot|invalid|denied|exception|fatal)/.test(s)) return 'error';
+        if (/(warn|warning|retry|timeout|stopped|disconnect)/.test(s)) return 'warn';
+        if (/(ok|started|listening|loaded|succeeded|connected|ready)/.test(s)) return 'success';
+        return 'info';
+      }
+
+      function formatTime(tsMs){
+        const n = Number(tsMs);
+        if (!Number.isFinite(n)) return '—';
+        const d = new Date(n);
+        const pad = v => String(v).padStart(2, '0');
+        const ms = String(d.getMilliseconds()).padStart(3, '0');
+        return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${ms}`;
+      }
+
+      function normalizeEntry(entry, idx){
+        const raw = typeof entry === 'object' ? entry : { msg: String(entry) };
+        const msg = raw.msg || raw.message || raw.text || JSON.stringify(raw);
+        const source = inferSource(msg);
+        const severity = inferSeverity(msg);
+        return {
+          id: raw.id ?? idx,
+          ts_ms: raw.ts_ms ?? raw.ts ?? Date.now(),
+          time: formatTime(raw.ts_ms ?? raw.ts),
+          source,
+          severity,
+          msg: cleanMessage(msg, source),
+          raw,
+          searchable: `${source} ${msg} ${JSON.stringify(raw)}`.toLowerCase(),
+        };
+      }
+
+      function prettyRaw(entry){
+        try { return JSON.stringify(entry.raw, null, 2); }
+        catch { return String(entry.raw); }
+      }
+
+      function updateSourceChips(){
+        const set = new Set(state.all.map(x => x.source));
+        const ordered = sourcePriority.filter(x => x === 'ALL' || set.has(x)).concat([...set].filter(x => !sourcePriority.includes(x)).sort());
+        el.sourceFilter.innerHTML = ordered.map(source => `
+          <button class="diag-chip ${state.source === source ? 'is-active' : ''}" data-source="${escapeHtml(source)}" type="button">${escapeHtml(source)}</button>
+        `).join('');
+        el.sourceFilter.querySelectorAll('[data-source]').forEach(btn => {
+          btn.addEventListener('click', () => {
+            state.source = btn.dataset.source;
+            applyFilters();
+          });
+        });
+      }
+
+      function renderList(){
+        if (!state.visible.length){
+          el.list.innerHTML = `<div class="diag-empty">No log entries match the current filters. A little silence from the machine for once.</div>`;
+          renderDetail(null);
+          return;
+        }
+        el.list.innerHTML = state.visible.map(entry => {
+          const selected = String(entry.id) === String(state.selectedId);
+          return `
+            <div class="diag-row ${selected ? 'is-selected' : ''}" data-id="${escapeHtml(entry.id)}">
+              <div class="diag-time">${escapeHtml(entry.time)}</div>
+              <div><span class="diag-source diag-source--${escapeHtml(entry.source)}">${escapeHtml(entry.source)}</span></div>
+              <div class="diag-msg">${escapeHtml(state.pretty ? entry.msg : JSON.stringify(entry.raw))}</div>
+              <div class="diag-sev diag-sev--${escapeHtml(entry.severity)}"></div>
+            </div>`;
+        }).join('');
+        el.list.querySelectorAll('.diag-row').forEach(row => row.addEventListener('click', () => {
+          state.selectedId = row.dataset.id;
+          renderList();
+          renderDetail(state.visible.find(x => String(x.id) === String(state.selectedId)) || null);
+        }));
+        const selected = state.visible.find(x => String(x.id) === String(state.selectedId)) || state.visible[0];
+        state.selectedId = selected ? selected.id : null;
+        if (selected) renderDetail(selected);
+        if (el.autoScroll.checked) el.list.scrollTop = el.list.scrollHeight;
+      }
+
+      function renderDetail(entry){
+        if (!entry){
+          el.detailTitle.textContent = 'No entry selected';
+          el.detailMeta.textContent = 'Pick a row on the left to inspect it properly.';
+          el.detailMessage.textContent = 'Nothing selected yet.';
+          el.detailRaw.textContent = '{ }';
+          return;
+        }
+        el.detailTitle.textContent = `${entry.source} • ${entry.severity.toUpperCase()}`;
+        el.detailMeta.textContent = `${entry.time} • id ${entry.id}`;
+        el.detailMessage.textContent = entry.msg;
+        el.detailRaw.textContent = prettyRaw(entry);
+      }
+
+      function applyFilters(){
+        const search = state.search.trim().toLowerCase();
+        state.visible = state.all.filter(entry => {
+          if (state.source !== 'ALL' && entry.source !== state.source) return false;
+          if (state.importantOnly && !['warn','error'].includes(entry.severity)) return false;
+          if (search && !entry.searchable.includes(search)) return false;
+          return true;
+        });
+        el.visibleCount.textContent = String(state.visible.length);
+        el.loadedCount.textContent = String(state.all.length);
+        el.sourceCount.textContent = String(new Set(state.all.map(x => x.source)).size);
+        const lastError = [...state.all].reverse().find(x => x.severity === 'error');
+        el.lastError.textContent = lastError ? `${lastError.source}: ${lastError.msg}` : 'None';
+        el.footerLeft.textContent = `${state.visible.length} of ${state.all.length} entries displayed`;
+        el.footerRight.textContent = state.pretty ? 'Pretty view' : 'Raw view';
+        updateSourceChips();
+        renderList();
+      }
+
+      async function fetchLog(){
+        if (state.clearView) return;
+        try {
+          const res = await fetch('/api/log', { cache: 'no-store' });
+          const text = await res.text();
+          let parsed;
+          try { parsed = normalizePayload(JSON.parse(text)); }
+          catch { parsed = textToEntries(text); }
+          state.all = parsed.map(normalizeEntry);
+          applyFilters();
+        } catch (err) {
+          state.all = [normalizeEntry({ id: 'fetch-error', msg: `HTTP: Failed to load /api/log: ${err && err.message ? err.message : err}` }, 0)];
+          applyFilters();
+        }
+      }
+
+      el.search.addEventListener('input', e => { state.search = e.target.value || ''; applyFilters(); });
+      el.importantOnly.addEventListener('change', e => { state.importantOnly = !!e.target.checked; applyFilters(); });
+      el.btnPretty.addEventListener('click', () => {
+        state.pretty = !state.pretty;
+        el.btnPretty.textContent = state.pretty ? 'Raw' : 'Pretty';
+        applyFilters();
+      });
+      el.btnClear.addEventListener('click', () => {
+        state.clearView = true;
+        state.all = [];
+        state.visible = [];
+        applyFilters();
+      });
+      el.btnCopyLog.addEventListener('click', async () => {
+        const text = state.visible.map(entry => state.pretty ? `[${entry.time}] [${entry.source}] ${entry.msg}` : JSON.stringify(entry.raw)).join('\n');
+        await navigator.clipboard.writeText(text);
+      });
+      el.btnCopySelected.addEventListener('click', async () => {
+        const entry = state.visible.find(x => String(x.id) === String(state.selectedId));
+        if (!entry) return;
+        await navigator.clipboard.writeText(prettyRaw(entry));
+      });
+      el.btnBack.addEventListener('click', () => { window.location.href = '/app/index.html'; });
+
+      fetchLog();
+      setInterval(fetchLog, 2000);
+    })();
+  </script>
 </body>
 </html>

--- a/Mode-S Client/assets/app/index.html
+++ b/Mode-S Client/assets/app/index.html
@@ -10,41 +10,59 @@
   <div class="app">
     <header class="topbar">
       <div class="brand">
-       <div class="brand__mark"><img src="/assets/icons/RClogo.svg" alt="RadarController" style="width:100%;height:100%;display:block;opacity:0.8;border-radius:inherit;" /></div>
+        <div class="brand__mark"><img src="/assets/icons/RClogo.svg" alt="RadarController" style="width:100%;height:100%;display:block;opacity:0.8;border-radius:inherit;" /></div>
         <div class="brand__text">
           <div class="brand__title">RadarController</div>
           <div class="brand__subtitle">Mode‑S Client</div>
         </div>
       </div>
 
-      <div class="topbar__metrics" id="topMetrics">
-        <div class="pill"><span class="pill__k">Viewers</span><span class="pill__v" id="mViewers">—</span></div>
-        <div class="pill"><span class="pill__k">Followers</span><span class="pill__v" id="mFollowers">—</span></div>
-        <div class="pill"><span class="pill__k">Aircraft</span><span class="pill__v" id="mAircraft">—</span></div>
-        <div class="pill pill--status"><span class="dot" id="mDot"></span><span class="pill__k">Status</span><span class="pill__v" id="mStatus">Idle</span></div>
-      </div>
-
       <div class="topbar__actions">
         <button class="btn btn--primary" id="btnStartAll">Start All Platforms</button>
         <button class="btn btn--ghost" id="btnOpenSettings">Settings</button>
+        <button class="btn btn--ghost" id="btnOpenDiagnostics" type="button">Diagnostics</button>
         <button class="btn btn--primary" id="btnOpenChat">Open Chat</button>
       </div>
     </header>
 
-    <main class="grid">
-      <section class="card card--wide">
-        <div class="card__head">
-          <div class="card__title">Platforms</div>
-          <div class="card__hint">Start/Restart and Stop each platform. Settings are saved locally.</div>
+    <div class="topbar__metrics" id="topMetrics">
+      <div class="pill"><span class="pill__k">Viewers</span><span class="pill__v" id="mViewers">—</span></div>
+      <div class="pill"><span class="pill__k">Followers</span><span class="pill__v" id="mFollowers">—</span></div>
+      <div class="pill pill--status"><span class="dot" id="mDot"></span><span class="pill__k">Status</span><span class="pill__v" id="mStatus">Idle</span></div>
+      <div class="pill"><span class="pill__k">Aircraft</span><span class="pill__v" id="mAircraft">—</span></div>
+    </div>
+
+    <main class="grid grid--single">
+      <section class="card card--wide home-platforms">
+        <div class="card__head home-platforms__head">
+          <div>
+            <div class="card__title">Platforms</div>
+            <div class="card__hint">Manage your linked accounts, or start or stop each platform.</div>
+          </div>
+          <div class="home-platforms__summary">
+            <div class="home-kpi">
+              <span class="home-kpi__k">Linked accounts</span>
+              <span class="home-kpi__v" id="linkedAccountsCount">0 / 3</span>
+            </div>
+            <div class="home-kpi">
+              <span class="home-kpi__k">Live platforms</span>
+              <span class="home-kpi__v" id="livePlatformsCount">0</span>
+            </div>
+          </div>
         </div>
 
-        <div class="platforms">
-          <div class="platform" data-platform="tiktok">
+        <div class="platforms platforms--home">
+          <div class="platform platform--home" data-platform="tiktok">
             <div class="platform__head">
-              <img class="platform__icon" src="/assets/icons/tiktok-icon.svg" alt="TikTok" />
-              <div class="platform__meta">
-                <div class="platform__name">TikTok</div>
-                <div class="platform__sub" id="tiktokState">Disconnected</div>
+              <div class="platform__identity">
+                <img class="platform__icon" src="/assets/icons/tiktok-icon.svg" alt="TikTok" />
+                <div class="platform__meta">
+                  <div class="platform__name">TikTok</div>
+                  <div class="platform__statusline">
+                    <span class="platform__state-dot" id="tiktokStateDot" aria-hidden="true"></span>
+                    <span class="platform__sub" id="tiktokState">Disconnected</span>
+                  </div>
+                </div>
               </div>
               <div class="platform__right">
                 <span class="badge" id="tiktokBadge">Offline</span>
@@ -52,11 +70,12 @@
             </div>
 
             <div class="platform__body">
-              <label class="field">
+              <div class="platform__section-label">Linked account</div>
+              <label class="field field--account">
                 <span class="field__k">Username</span>
-                <div class="field__row">
+                <div class="field__row field__row--account">
                   <input class="input" id="tiktokUser" placeholder="@username" />
-                  <button class="btn btn--ghost" data-action="set">SET</button>
+                  <button class="btn btn--ghost" data-action="set">Save</button>
                 </div>
               </label>
 
@@ -66,18 +85,23 @@
               </div>
 
               <div class="platform__actions">
-                <button class="btn btn--primary" data-action="start">Start/Restart</button>
+                <button class="btn btn--primary" data-action="start">Start / Restart</button>
                 <button class="btn btn--danger" data-action="stop" disabled>Stop</button>
               </div>
             </div>
           </div>
 
-          <div class="platform" data-platform="twitch">
+          <div class="platform platform--home" data-platform="twitch">
             <div class="platform__head">
-              <img class="platform__icon" src="/assets/icons/twitch-icon.svg" alt="Twitch" />
-              <div class="platform__meta">
-                <div class="platform__name">Twitch</div>
-                <div class="platform__sub" id="twitchState">Disconnected</div>
+              <div class="platform__identity">
+                <img class="platform__icon" src="/assets/icons/twitch-icon.svg" alt="Twitch" />
+                <div class="platform__meta">
+                  <div class="platform__name">Twitch</div>
+                  <div class="platform__statusline">
+                    <span class="platform__state-dot" id="twitchStateDot" aria-hidden="true"></span>
+                    <span class="platform__sub" id="twitchState">Disconnected</span>
+                  </div>
+                </div>
               </div>
               <div class="platform__right">
                 <span class="badge" id="twitchBadge">Offline</span>
@@ -85,11 +109,12 @@
             </div>
 
             <div class="platform__body">
-              <label class="field">
+              <div class="platform__section-label">Linked account</div>
+              <label class="field field--account">
                 <span class="field__k">Channel</span>
-                <div class="field__row">
+                <div class="field__row field__row--account">
                   <input class="input" id="twitchUser" placeholder="channel_name" />
-                  <button class="btn btn--ghost" data-action="set">SET</button>
+                  <button class="btn btn--ghost" data-action="set">Save</button>
                 </div>
               </label>
 
@@ -99,18 +124,23 @@
               </div>
 
               <div class="platform__actions">
-                <button class="btn btn--primary" data-action="start">Start/Restart</button>
+                <button class="btn btn--primary" data-action="start">Start / Restart</button>
                 <button class="btn btn--danger" data-action="stop" disabled>Stop</button>
               </div>
             </div>
           </div>
 
-          <div class="platform" data-platform="youtube">
+          <div class="platform platform--home" data-platform="youtube">
             <div class="platform__head">
-              <img class="platform__icon" src="/assets/icons/youtube-icon.svg" alt="YouTube" />
-              <div class="platform__meta">
-                <div class="platform__name">YouTube</div>
-                <div class="platform__sub" id="youtubeState">Disconnected</div>
+              <div class="platform__identity">
+                <img class="platform__icon" src="/assets/icons/youtube-icon.svg" alt="YouTube" />
+                <div class="platform__meta">
+                  <div class="platform__name">YouTube</div>
+                  <div class="platform__statusline">
+                    <span class="platform__state-dot" id="youtubeStateDot" aria-hidden="true"></span>
+                    <span class="platform__sub" id="youtubeState">Disconnected</span>
+                  </div>
+                </div>
               </div>
               <div class="platform__right">
                 <span class="badge" id="youtubeBadge">Offline</span>
@@ -118,11 +148,12 @@
             </div>
 
             <div class="platform__body">
-              <label class="field">
+              <div class="platform__section-label">Linked account</div>
+              <label class="field field--account">
                 <span class="field__k">Handle / Channel</span>
-                <div class="field__row">
+                <div class="field__row field__row--account">
                   <input class="input" id="youtubeUser" placeholder="UC... or @handle" />
-                  <button class="btn btn--ghost" data-action="set">SET</button>
+                  <button class="btn btn--ghost" data-action="set">Save</button>
                 </div>
               </label>
 
@@ -132,20 +163,23 @@
               </div>
 
               <div class="platform__actions">
-                <button class="btn btn--primary" data-action="start">Start/Restart</button>
+                <button class="btn btn--primary" data-action="start">Start / Restart</button>
                 <button class="btn btn--danger" data-action="stop" disabled>Stop</button>
               </div>
             </div>
           </div>
         </div>
-      </section>
 
-      <section class="card">
-        <div class="card__head">
-          <div class="card__title">Log</div>
-          <div class="card__hint">Live operational messages from the client.</div>
+        <div class="home-strip">
+          <div class="home-strip__item">
+            <span class="home-strip__dot"></span>
+            <span class="home-strip__text">Connected means the platform is configured and the client can currently see or talk to that integration. In short, you're ready to go live.</span>
+          </div>
+          <div class="home-strip__item">
+            <span class="home-strip__dot home-strip__dot--blue"></span>
+            <span class="home-strip__text">Problems, errors and alerts related to the app are now in the Diagnostics page. Stream alerts show up in the chat window.</span>
+          </div>
         </div>
-        <div class="log" id="log"></div>
       </section>
     </main>
 
@@ -156,5 +190,15 @@
   </div>
 
   <script src="/app/app.js"></script>
+  <script>
+    (function () {
+      const btn = document.getElementById('btnOpenDiagnostics');
+      if (btn) {
+        btn.addEventListener('click', function () {
+          window.location.href = '/app/diagnostics.html';
+        });
+      }
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
This PR completes the web-facing work for diagnostics and tidies the app home screen layout.

It moves the operational log off the front page and into `diagnostics.html`, then improves both screens so they feel like part of the same UI rather than two unrelated control panels taped together.

Fixes #102

## What changed

### Diagnostics
- moved the log viewer out of the app home page
- added a dedicated Diagnostics page log panel
- wired the Diagnostics page to read from `/api/log`
- added log actions:
  - copy log
  - copy selected entry
  - clear current view
- improved diagnostics presentation from a raw blob into a structured viewer
- added better scrolling behaviour so only the log list scrolls
- fixed long message/raw text wrapping in the details pane
- shortened the search placeholder to fit correctly

### Home page
- removed the home page log panel
- added/kept access to Diagnostics from the main app UI
- moved the top metrics out of the header into their own section between the header and Platforms
- refined the metrics styling so the band fits the page more naturally
- fixed the status metric dot alignment
- kept the rest of the page intact while improving layout consistency

## Why

The app home page should act as the main control surface, not a dumping ground for raw operational logs.

Moving the log into Diagnostics makes the UI clearer:
- home page = platform control and high-level state
- diagnostics = detailed technical visibility

This also lines up with the intent of issue #102:
- web log visible
- fetched from `/api/log`
- clear/copy actions available
- native/front-page style log removed from the main app experience