### PR TITLE
Fix Twitch EventSub reconnect handling on token refresh

### DIFF
--- a/Mode-S Client/src/Mode-S Client.cpp
+++ b/Mode-S Client/src/Mode-S Client.cpp
@@ -713,7 +713,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 return true;
                 };
             opt.stop_twitch = [&]() -> bool {
-                PlatformControl::StopTwitch(twitch, state, [](const std::wstring& s) { LogLine(s); });
+                PlatformControl::StopTwitch(twitch, twitchEventSub, state, [](const std::wstring& s) { LogLine(s); });
                 return true;
                 };
 
@@ -872,42 +872,15 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             twitchAuth.on_tokens_updated = [&](const std::string& access,
                 const std::string& /*refresh*/,
                 const std::string& login) {
-                    LogLine(L"TWITCH: tokens updated - restarting EventSub + IRC");
-
                     // Defensive: validated login can be empty depending on validate/refresh edge cases.
                     const std::string effective_login = !login.empty() ? login : config.twitch_login;
+                    LogLine(L"TWITCH: tokens updated - refreshing EventSub token and restarting IRC");
 
+                    // Keep config aligned with the validated login we actually use elsewhere.
+                    config.twitch_login = effective_login;
+
+                    // EventSub handles token changes by reconnecting/resubscribing internally.
                     twitchEventSub.UpdateAccessToken(access);
-                    twitchEventSub.Stop();
-                    twitchEventSub.Start(
-                        config.twitch_client_id,
-                        access,
-                        config.twitch_login,
-
-                        // EventSub -> Chat (optional messages you inject)
-                        [&](const ChatMessage& msg) {
-                            ChatMessage c = msg;
-                            c.is_event = true;
-                            chat.Add(std::move(c));
-                        },
-
-                        // EventSub -> Alerts overlay
-                        [&](const nlohmann::json& ev) { state.add_twitch_eventsub_event(ev); },
-
-                        // EventSub -> Status/health (THIS is what makes /api/twitch/eventsub/status meaningful)
-                        [&](const nlohmann::json& st) {
-                            state.set_twitch_eventsub_status(st);
-
-                            // Push new error events into AppState's ring buffer (optional but useful)
-                            static std::uint64_t last_seq = 0;
-                            const std::uint64_t seq = st.value("last_error_seq", (std::uint64_t)0);
-                            if (seq != 0 && seq != last_seq) {
-                                last_seq = seq;
-                                const std::string msg = st.value("last_error", std::string{});
-                                if (!msg.empty()) state.push_twitch_eventsub_error(msg);
-                            }
-                        }
-                    );
 
                     PlatformControl::StartOrRestartTwitchIrc(
                         twitch, state, chat,

--- a/Mode-S Client/src/platform/PlatformControl.cpp
+++ b/Mode-S Client/src/platform/PlatformControl.cpp
@@ -8,6 +8,7 @@
 
 #include "tiktok/TikTokSidecar.h"
 #include "twitch/TwitchIrcWsClient.h"
+#include "twitch/TwitchEventSubWsClient.h"
 #include "chat/ChatAggregator.h"
 #include "AppState.h"
 
@@ -291,11 +292,12 @@ void StopYouTube(TikTokSidecar& youtube, AppState& state, LogFn log) {
     state.set_youtube_viewers(0);
     if (log) log(L"YOUTUBE: stopped.");
 }
-void StopTwitch(TwitchIrcWsClient& twitch, AppState& state, LogFn log) {
+void StopTwitch(TwitchIrcWsClient& twitch, TwitchEventSubWsClient& twitchEventSub, AppState& state, LogFn log) {
     twitch.stop();
+    twitchEventSub.Stop();
     state.set_twitch_live(false);
     state.set_twitch_viewers(0);
-    if (log) log(L"TWITCH: stopped.");
+    if (log) log(L"TWITCH: stopped IRC + EventSub.");
 }
 
 } // namespace PlatformControl

--- a/Mode-S Client/src/platform/PlatformControl.h
+++ b/Mode-S Client/src/platform/PlatformControl.h
@@ -9,6 +9,7 @@ class AppState;
 class ChatAggregator;
 class TikTokSidecar;
 class TwitchIrcWsClient;
+class TwitchEventSubWsClient;
 struct AppConfig;
 
 namespace PlatformControl {
@@ -47,6 +48,6 @@ bool StartOrRestartTwitchIrc(
 // Stops helpers (also clears AppState live flags + viewers to avoid stale UI).
 void StopTikTok(TikTokSidecar& tiktok, AppState& state, LogFn log);
 void StopYouTube(TikTokSidecar& youtube, AppState& state, LogFn log);
-void StopTwitch(TwitchIrcWsClient& twitch, AppState& state, LogFn log);
+void StopTwitch(TwitchIrcWsClient& twitch, TwitchEventSubWsClient& twitchEventSub, AppState& state, LogFn log);
 
 } // namespace PlatformControl


### PR DESCRIPTION
This fixes Twitch token refresh handling so EventSub reconnects cleanly with the refreshed access token, while also tightening overall Twitch start/stop behaviour.

## What changed

- removed the duplicate EventSub restart path during OAuth token refresh
- kept a single reconnect flow by using the existing `UpdateAccessToken()` logic
- aligned refresh handling so both IRC and EventSub use the same effective Twitch login
- updated Twitch stop handling so stopping Twitch from the UI stops both IRC and EventSub
- added the required EventSub include in `PlatformControl.cpp` for compilation

## Why

Previously, the token refresh path was doing too much:
- `UpdateAccessToken()` already triggered EventSub reconnect/resubscribe
- the app was then also doing an explicit `Stop()` + `Start()` for EventSub

That made the refresh flow more race-prone than necessary.

There was also an inconsistency where IRC used the validated/effective login while EventSub used `config.twitch_login`, plus the dashboard stop path only stopped IRC and could leave EventSub running.

## Result

- mid-stream token refresh now has one clear EventSub reconnect path
- IRC and EventSub stay aligned on login state
- stopping Twitch from the UI now fully stops Twitch connectivity

Fixes #61