### PR TITLE
Refactor runtime ownership, Helix lifecycle and app path helper out of Mode-S Client.cpp

### DIFF
--- a/Mode-S Client/Mode-S Client.vcxproj
+++ b/Mode-S Client/Mode-S Client.vcxproj
@@ -193,6 +193,7 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
     <ClInclude Include="integrations\tiktok\TikTokSidecar.h" />
     <ClInclude Include="integrations\twitch\TwitchAuth.h" />
     <ClInclude Include="integrations\twitch\TwitchEventSubWsClient.h" />
+    <ClInclude Include="integrations\twitch\TwitchHelixController.h" />
     <ClInclude Include="integrations\twitch\TwitchHelixService.h" />
     <ClInclude Include="integrations\twitch\TwitchIrcWsClient.h" />
     <ClInclude Include="integrations\youtube\YouTubeAuth.h" />
@@ -205,6 +206,7 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
     <ClInclude Include="src\app\AppShutdown.h" />
     <ClInclude Include="src\bot\BotReplyRouter.h" />
     <ClInclude Include="src\chat\ChatAggregator.h" />
+    <ClInclude Include="src\core\AppPaths.h" />
     <ClInclude Include="src\core\StringUtil.h" />
     <ClInclude Include="src\floating\FloatingChat.h" />
     <ClInclude Include="src\http\LocalApiClient.h" />
@@ -225,6 +227,7 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
     <ClCompile Include="integrations\tiktok\TikTokSidecar.cpp" />
     <ClCompile Include="integrations\twitch\TwitchAuth.cpp" />
     <ClCompile Include="integrations\twitch\TwitchEventSubWsClient.cpp" />
+    <ClCompile Include="integrations\twitch\TwitchHelixController.cpp" />
     <ClCompile Include="integrations\twitch\TwitchHelixService.cpp" />
     <ClCompile Include="integrations\twitch\TwitchIrcWsClient.cpp" />
     <ClCompile Include="integrations\youtube\YouTubeAuth.cpp" />
@@ -235,6 +238,7 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
     <ClCompile Include="src\app\AppRuntime.cpp" />
     <ClCompile Include="src\app\AppShutdown.cpp" />
     <ClCompile Include="src\chat\ChatAggregator.cpp" />
+    <ClCompile Include="src\core\AppPaths.cpp" />
     <ClCompile Include="src\core\StringUtil.cpp" />
     <ClCompile Include="src\floating\FloatingChat.cpp" />
     <ClCompile Include="src\http\LocalApiClient.cpp" />

--- a/Mode-S Client/integrations/twitch/TwitchHelixController.cpp
+++ b/Mode-S Client/integrations/twitch/TwitchHelixController.cpp
@@ -1,0 +1,56 @@
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+
+#include "twitch/TwitchHelixController.h"
+
+#include "AppConfig.h"
+#include "AppState.h"
+#include "core/StringUtil.h"
+#include "twitch/TwitchHelixService.h"
+#include "log/UiLog.h"
+
+namespace TwitchHelixController {
+
+void RestartPoller(Dependencies& deps, const std::string& reason)
+{
+    const std::string login = deps.config.twitch_login;
+    if (login.empty()) return;
+
+    if (deps.boundLogin == login && deps.thread.joinable()) {
+        return;
+    }
+
+    LogLine(L"TWITCH: restarting Helix poller (" + ToW(reason) + L")");
+
+    if (deps.thread.joinable()) {
+        deps.running = false;
+        deps.thread.join();
+    }
+
+    deps.state.set_twitch_viewers(0);
+    deps.state.set_twitch_followers(0);
+    deps.state.set_twitch_live(false);
+
+    deps.running = true;
+    deps.boundLogin = login;
+
+    deps.thread = StartTwitchHelixPoller(
+        deps.hwnd,
+        deps.config,
+        deps.state,
+        deps.running,
+        0,
+        TwitchHelixUiCallbacks{
+            [](const std::wstring& s) { LogLine(s); },
+            [&](const std::wstring& /*s*/) {},
+            [&](bool /*live*/) {},
+            [&](int /*v*/) {},
+            [&](int /*f*/) {}
+        }
+    );
+}
+
+} // namespace TwitchHelixController

--- a/Mode-S Client/integrations/twitch/TwitchHelixController.h
+++ b/Mode-S Client/integrations/twitch/TwitchHelixController.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <atomic>
+#include <string>
+#include <thread>
+#include <windows.h>
+
+struct AppConfig;
+class AppState;
+
+namespace TwitchHelixController {
+
+struct Dependencies {
+    HWND hwnd;
+    AppConfig& config;
+    AppState& state;
+    std::thread& thread;
+    std::atomic<bool>& running;
+    std::string& boundLogin;
+};
+
+void RestartPoller(Dependencies& deps, const std::string& reason);
+
+} // namespace TwitchHelixController

--- a/Mode-S Client/src/Mode-S Client.cpp
+++ b/Mode-S Client/src/Mode-S Client.cpp
@@ -32,16 +32,18 @@
 #include "app/AppBootstrap.h"
 #include "app/AppRuntime.h"
 #include "app/AppShutdown.h"
+#include "core/AppPaths.h"
 #include "core/StringUtil.h"
 #include "http/HttpServer.h"
 #include "chat/ChatAggregator.h"
 #include "twitch/TwitchHelixService.h"
+#include "twitch/TwitchHelixController.h"
 #include "twitch/TwitchIrcWsClient.h"
 #include "twitch/TwitchEventSubWsClient.h"
 #include "twitch/TwitchAuth.h"
-#include "youtube/YouTubeAuth.h"
 #include "tiktok/TikTokSidecar.h"
 #include "tiktok/TikTokFollowersService.h"
+#include "youtube/YouTubeAuth.h"
 #include "youtube/YouTubeLiveChatService.h"
 #include "euroscope/EuroScopeIngestService.h"
 #include "obs/ObsWsClient.h"
@@ -68,41 +70,6 @@ static std::unique_ptr<class FloatingChat> gFloatingChat;
 static AppRuntime gRuntime;
 
 // --------------------------- Helpers ----------------------------------------
-static std::wstring GetExeDir()
-{
-    wchar_t path[MAX_PATH];
-    GetModuleFileNameW(nullptr, path, MAX_PATH);
-    std::wstring p = path;
-    auto pos = p.find_last_of(L"\\/");
-    return (pos == std::wstring::npos) ? L"." : p.substr(0, pos);
-}
-
-// Read Twitch user access token from config.json.
-// Stored at: { "twitch": { "user_access_token": "..." } }
-static std::string ReadTwitchUserAccessToken()
-{
-    auto try_path = [](const std::filesystem::path& p) -> std::string {
-        try {
-            std::ifstream f(p);
-            if (!f.is_open()) return {};
-            nlohmann::json j;
-            f >> j;
-            return j.value("twitch", nlohmann::json::object()).value("user_access_token", "");
-        }
-        catch (...) {
-            return {};
-        }
-        };
-
-    // Prefer config.json next to the exe
-    std::filesystem::path p1 = std::filesystem::path(GetExeDir()) / "config.json";
-    std::string tok = try_path(p1);
-    if (!tok.empty()) return tok;
-
-    // Fallback: current working directory
-    return try_path(std::filesystem::path("config.json"));
-}
-
 static void JoinWithTimeout(std::thread& t, DWORD timeoutMs, const wchar_t* name)
 {
     if (!t.joinable()) return;
@@ -251,42 +218,16 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 
     // Restartable Helix poller (needed when Twitch channel/login changes).
     auto RestartTwitchHelixPoller = [&](const std::string& reason) {
-        const std::string login = gRuntime.config.twitch_login;
-        if (login.empty()) return;
-
-        if (gRuntime.twitchHelixBoundLogin == login && gRuntime.twitchHelixThread.joinable()) {
-            return;
-        }
-
-        LogLine(L"TWITCH: restarting Helix poller (" + ToW(reason) + L")");
-
-        if (gRuntime.twitchHelixThread.joinable()) {
-            gRuntime.twitchHelixRunning = false;
-            gRuntime.twitchHelixThread.join();
-        }
-
-        gRuntime.state.set_twitch_viewers(0);
-        gRuntime.state.set_twitch_followers(0);
-        gRuntime.state.set_twitch_live(false);
-
-        gRuntime.twitchHelixRunning = true;
-        gRuntime.twitchHelixBoundLogin = login;
-
-        gRuntime.twitchHelixThread = StartTwitchHelixPoller(
+        TwitchHelixController::Dependencies deps{
             hwnd,
             gRuntime.config,
             gRuntime.state,
+            gRuntime.twitchHelixThread,
             gRuntime.twitchHelixRunning,
-            0,
-            TwitchHelixUiCallbacks{
-                [](const std::wstring& s) { LogLine(s); },
-                [&](const std::wstring& /*s*/) {},
-                [&](bool /*live*/) {},
-                [&](int /*v*/) {},
-                [&](int /*f*/) {}
-            }
-        );
+            gRuntime.twitchHelixBoundLogin
         };
+        TwitchHelixController::RestartPoller(deps, reason);
+    };
 
     switch (msg) {
 

--- a/Mode-S Client/src/core/AppPaths.cpp
+++ b/Mode-S Client/src/core/AppPaths.cpp
@@ -1,0 +1,14 @@
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+
+#include "core/AppPaths.h"
+
+std::wstring GetExeDir()
+{
+    wchar_t path[MAX_PATH];
+    GetModuleFileNameW(nullptr, path, MAX_PATH);
+    std::wstring p = path;
+    auto pos = p.find_last_of(L"\\/");
+    return (pos == std::wstring::npos) ? L"." : p.substr(0, pos);
+}

--- a/Mode-S Client/src/core/AppPaths.h
+++ b/Mode-S Client/src/core/AppPaths.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+std::wstring GetExeDir();


### PR DESCRIPTION
This continues the #94 refactor by moving more long-lived ownership and platform-specific behaviour out of `Mode-S Client.cpp`.

## What changed

### AppRuntime
- added `app/AppRuntime.*`
- moved long-lived runtime ownership out of function-statics in `WndProc`
- centralised app services, worker threads, and lifecycle flags into a dedicated runtime object
- moved bootstrap/shutdown dependency construction into `AppRuntime`

### Twitch Helix lifecycle
- added `TwitchHelixController.*` alongside the other Twitch integration files
- moved Helix restart/poller lifecycle logic out of `Mode-S Client.cpp`
- kept `Mode-S Client.cpp` responsible only for calling into the controller, rather than owning the Helix orchestration inline

### App paths
- added `core/AppPaths.*`
- moved `GetExeDir()` out of `Mode-S Client.cpp`