### PR TITLE
Add current subscriber panels to post-stream overlays

### DIFF
--- a/Mode-S Client/Mode-S Client.vcxproj
+++ b/Mode-S Client/Mode-S Client.vcxproj
@@ -196,9 +196,11 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
     <ClInclude Include="integrations\twitch\TwitchHelixController.h" />
     <ClInclude Include="integrations\twitch\TwitchHelixService.h" />
     <ClInclude Include="integrations\twitch\TwitchIrcWsClient.h" />
+    <ClInclude Include="integrations\twitch\TwitchSupporterProvider.h" />
     <ClInclude Include="integrations\youtube\YouTubeAuth.h" />
     <ClInclude Include="integrations\youtube\YouTubeLiveChatService.h" />
     <ClInclude Include="integrations\youtube\YouTubeSidecar.h" />
+    <ClInclude Include="integrations\youtube\YouTubeSupporterProvider.h" />
     <ClInclude Include="src\AppConfig.h" />
     <ClInclude Include="src\AppState.h" />
     <ClInclude Include="src\app\AppBootstrap.h" />
@@ -215,6 +217,8 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
     <ClInclude Include="src\http\HttpServer.h" />
     <ClInclude Include="src\oauth\EmbeddedOAuthConfig.h" />
     <ClInclude Include="src\platform\PlatformControl.h" />
+    <ClInclude Include="src\supporter\RecentSupporter.h" />
+    <ClInclude Include="src\supporter\SupporterFeedService.h" />
     <ClInclude Include="src\ui\SplashScreen.h" />
     <ClInclude Include="src\ui\WebViewHost.h" />
     <ClInclude Include="src\ui\WindowEffects.h" />
@@ -233,9 +237,11 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
     <ClCompile Include="integrations\twitch\TwitchHelixController.cpp" />
     <ClCompile Include="integrations\twitch\TwitchHelixService.cpp" />
     <ClCompile Include="integrations\twitch\TwitchIrcWsClient.cpp" />
+    <ClCompile Include="integrations\twitch\TwitchSupporterProvider.cpp" />
     <ClCompile Include="integrations\youtube\YouTubeAuth.cpp" />
     <ClCompile Include="integrations\youtube\YouTubeLiveChatService.cpp" />
     <ClCompile Include="integrations\youtube\YouTubeSidecar.cpp" />
+    <ClCompile Include="integrations\youtube\YouTubeSupporterProvider.cpp" />
     <ClCompile Include="src\AppState.cpp" />
     <ClCompile Include="src\app\AppBootstrap.cpp" />
     <ClCompile Include="src\app\AppRuntime.cpp" />
@@ -249,6 +255,8 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
     <ClCompile Include="src\Mode-S Client.cpp" />
     <ClCompile Include="src\http\HttpServer.cpp" />
     <ClCompile Include="src\platform\PlatformControl.cpp" />
+    <ClCompile Include="src\supporter\RecentSupporter.cpp" />
+    <ClCompile Include="src\supporter\SupporterFeedService.cpp" />
     <ClCompile Include="src\ui\SplashScreen.cpp" />
     <ClCompile Include="src\ui\WebViewHost.cpp" />
     <ClCompile Include="src\ui\WindowEffects.cpp" />

--- a/Mode-S Client/Mode-S Client.vcxproj.filters
+++ b/Mode-S Client/Mode-S Client.vcxproj.filters
@@ -153,6 +153,18 @@
     <ClInclude Include="src\oauth\EmbeddedOAuthConfig.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\supporter\RecentSupporter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\supporter\SupporterFeedService.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="integrations\twitch\TwitchSupporterProvider.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="integrations\youtube\YouTubeSupporterProvider.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="integrations\obs\ObsWsClient.cpp">
@@ -243,6 +255,18 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\ui\WindowLayout.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\supporter\RecentSupporter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\supporter\SupporterFeedService.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="integrations\twitch\TwitchSupporterProvider.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="integrations\youtube\YouTubeSupporterProvider.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Mode-S Client/assets/overlay/landscape/26_post_stream.html
+++ b/Mode-S Client/assets/overlay/landscape/26_post_stream.html
@@ -11,6 +11,7 @@
     --stroke: rgba(255,255,255,.12);
     --text: rgba(233,238,247,.92);
     --muted: rgba(233,238,247,.70);
+    --soft: rgba(10,14,18,.35);
   }
 
   html,body{
@@ -100,15 +101,6 @@
     justify-content:center;
   }
 
-  .label{
-    color:var(--muted);
-    font-weight:650;
-    letter-spacing:.08em;
-    text-transform:uppercase;
-    font-size:10px;
-    margin-right:2px;
-  }
-
   @media (max-width: 1000px) {
     .bar{
       flex-direction:column;
@@ -116,25 +108,12 @@
       gap:10px;
       padding:10px 18px;
     }
-
-    .left{
-      width:100%;
-      justify-content:center;
-      text-align:center;
-    }
-
-    .right{
-      width:100%;
-      justify-content:center;
-    }
+    .left{ width:100%; justify-content:center; text-align:center; }
+    .right{ width:100%; justify-content:center; }
   }
 
   @media (max-width: 600px) {
-    .right{
-      flex-direction:column;
-      align-items:center;
-      gap:8px;
-    }
+    .right{ flex-direction:column; align-items:center; gap:8px; }
   }
 
   .stage{
@@ -174,6 +153,7 @@
     position:absolute;
     top:0; left:0; right:0;
     height:74px;
+    z-index:5;
   }
 
   .header .bar{
@@ -193,17 +173,20 @@
     position:absolute;
     left: 26px;
     right: 26px;
-    top: calc(74px + 28px);
+    top: 98px;
     bottom: 26px;
     display:grid;
-    grid-template-columns: 1.35fr .65fr;
+    grid-template-columns: minmax(720px, 1.2fr) minmax(400px, .8fr);
     gap: 26px;
-    align-items:end;
+    align-items:start;
+    overflow:hidden;
+    z-index:1;
   }
 
   .panel{
-    align-self:center;
+    align-self:start;
     max-width: 1100px;
+    min-height:0;
     padding: 26px 28px;
     border-radius: 18px;
     background: var(--panel);
@@ -211,6 +194,7 @@
     -webkit-backdrop-filter: blur(8px);
     border: 1px solid var(--stroke);
     box-shadow: 0 24px 60px rgba(0,0,0,.22);
+    box-sizing:border-box;
   }
 
   .startTitle{
@@ -354,15 +338,200 @@
     word-break:break-word;
   }
 
-  .radarSpinner{
-    justify-self:end;
-    align-self:end;
-    width: min(360px, 26vw);
-    height: min(360px, 26vw);
+  .sideColumn{
+    display:grid;
+    grid-template-rows: minmax(0, 1fr) auto;
+    gap:18px;
+    min-height:0;
+    height:100%;
+    max-height:100%;
+    overflow:hidden;
+    align-self:start;
+  }
+
+  .supportersPanel{
+    min-height:0;
+    height:100%;
+    max-height:100%;
+    display:flex;
+    flex-direction:column;
+    padding:20px;
+    overflow:hidden;
+    align-self:stretch;
+  }
+
+  .supportersHead{
+    display:flex;
+    align-items:flex-end;
+    justify-content:space-between;
+    gap:16px;
+    margin-bottom:16px;
+  }
+
+  .supportersTitle{
+    margin:0;
+    color:var(--text);
+    font-size:24px;
+    line-height:1;
+    font-weight:900;
+    letter-spacing:.12em;
+    text-transform:uppercase;
+  }
+
+  .supportersMeta{
+    color:var(--muted);
+    font-size:11px;
+    font-weight:700;
+    letter-spacing:.14em;
+    text-transform:uppercase;
+  }
+
+  .supportersViewport{
+    position:relative;
+    flex:1 1 auto;
+    min-height:0;
+    height:100%;
+    overflow:hidden;
+    border-radius:16px;
+    border:1px solid rgba(255,255,255,.10);
+    background:linear-gradient(180deg, rgba(255,255,255,.04), rgba(255,255,255,.02));
+    padding:12px;
+    box-sizing:border-box;
+  }
+
+  .supportersViewport::before,
+  .supportersViewport::after{
+    content:"";
+    position:absolute;
+    left:0;
+    right:0;
+    height:44px;
+    z-index:2;
+    pointer-events:none;
+  }
+
+  .supportersViewport::before{
+    top:0;
+    background:linear-gradient(180deg, rgba(18,22,28,.95), rgba(18,22,28,0));
+  }
+
+  .supportersViewport::after{
+    bottom:0;
+    background:linear-gradient(0deg, rgba(18,22,28,.95), rgba(18,22,28,0));
+  }
+
+  .supportersTrack{
+    --loop-distance: 0px;
+    display:flex;
+    flex-direction:column;
+    gap:9px;
+    will-change:transform;
+  }
+
+  .supportersTrack.scrolling {
+    animation:none;
+    transform:translate3d(0, 0, 0);
+  }
+
+  .supportersTrack.static {
+    animation:none;
+    transform:translate3d(0, 0, 0);
+  }
+
+  .supportersGroup{
+    display:flex;
+    flex-direction:column;
+    gap:9px;
+  }
+
+
+  .supporterRow{
+    display:grid;
+    grid-template-columns:auto 1fr auto;
+    gap:12px;
+    align-items:center;
+    padding:11px 13px;
+    border-radius:14px;
+    background:rgba(10,14,18,.34);
+    border:1px solid rgba(255,255,255,.10);
+  }
+
+  .supporterIcon{
+    width:34px;
+    height:34px;
+    border-radius:10px;
     display:grid;
     place-items:center;
-    opacity:.95;
+    background:rgba(30,109,255,.14);
+    border:1px solid rgba(255,255,255,.12);
+    flex:0 0 auto;
+  }
+
+  .supporterIcon svg{
+    width:18px;
+    height:18px;
+    fill:var(--text);
+    opacity:.92;
+  }
+
+  .supporterText{
+    min-width:0;
+    display:flex;
+    flex-direction:column;
+    gap:4px;
+  }
+
+  .supporterName{
+    color:var(--text);
+    font-size:15px;
+    font-weight:800;
+    letter-spacing:.01em;
+    white-space:nowrap;
+    overflow:hidden;
+    text-overflow:ellipsis;
+  }
+
+  .supporterSub{
+    color:var(--muted);
+    font-size:10px;
+    font-weight:700;
+    letter-spacing:.12em;
+    text-transform:uppercase;
+  }
+
+  .supporterBadge{
+    padding:7px 10px;
+    border-radius:999px;
+    border:1px solid rgba(255,255,255,.12);
+    background:rgba(255,255,255,.06);
+    color:var(--text);
+    font-size:10px;
+    font-weight:800;
+    letter-spacing:.12em;
+    text-transform:uppercase;
+    white-space:nowrap;
+  }
+
+  .supportersEmpty{
+    height:100%;
+    display:grid;
+    place-items:center;
+    padding:24px;
+    text-align:center;
+    color:var(--muted);
+    font-size:14px;
+    line-height:1.6;
+  }
+
+  .miniRadar{
+    justify-self:end;
+    width:min(160px, 11vw);
+    height:min(160px, 11vw);
+    display:grid;
+    place-items:center;
+    opacity:.9;
     filter: drop-shadow(0 18px 40px rgba(0,0,0,.22));
+    flex:0 0 auto;
   }
 
   .radar-logo{
@@ -425,15 +594,18 @@
     to { transform: rotate(360deg); }
   }
 
-  @media (max-width: 1400px){
-    .startTitle{ font-size: 74px; }
-    .main{ grid-template-columns: 1.5fr .5fr; }
+  @media (max-width: 1520px){
+    .startTitle{ font-size: 78px; }
+    .main{ grid-template-columns: 1fr 420px; }
   }
-  @media (max-width: 1100px){
+
+  @media (max-width: 1220px){
     .main{ grid-template-columns: 1fr; }
-    .radarSpinner{ display:none; }
-    .startTitle{ font-size: 66px; }
+    .sideColumn{ grid-template-rows:auto auto; }
+    .miniRadar{ display:none; }
+    .supportersPanel{ min-height:420px; }
   }
+
   @media (max-width: 700px){
     .startTitle{ font-size: 48px; }
     .thanks{ font-size:16px; }
@@ -442,11 +614,11 @@
     .ctaGrid{ grid-template-columns:1fr; }
     .ctaDiscord{ grid-column:span 1; }
     .ctaValue{ font-size:20px; }
+    .supportersTitle{ font-size:18px; }
   }
 
 </style>
 </head>
-
 <body>
   <div class="stage">
     <div class="field"></div>
@@ -465,7 +637,7 @@
             <span>Twitch</span>
           </div>
           <div class="stat">
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21.6 7.2c-.2-1-1-1.8-2-2C17.8 4.8 12 4.8 12 4.8s-5.8 0-7.6.4c-1 .2-1.8 1-2 2C2 9 2 12 2 12s0 3 .4 4.8c.2 1 1 1.8 2 2 1.8.4 7.6.4 7.6.4s5.8 0 7.6-.4c1-.2 1.8-1 2-2 .4-1.8.4-4.8.4-4.8s0-3-.4-4.8zM10 15.5v-7l6 3.5-6 3.5z"/></svg>
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21.6 7.2c-.2-1-1-1.8-2-2C17.8 4.8 12 4.8 12 4.8s-5.8 0-7.6.4c-1 .2-1.8 1-2 2C2 9 2 12 2 12s0 3 .4 4.8c.2 1 1 1.8 2 2 1.8.4 7.6.4 7.6.4s5.8 0 7.6-.4c1-.2 1.8-1.8 2-2 .4-1.8.4-4.8.4-4.8s0-3-.4-4.8zM10 15.5v-7l6 3.5-6 3.5z"/></svg>
             <span>YouTube</span>
           </div>
           <div class="stat">
@@ -530,9 +702,27 @@
         </div>
       </div>
 
-      <div class="radarSpinner" aria-hidden="true">
-        <div class="radar-logo">
-          <span class="sweep"></span>
+      <div class="sideColumn">
+        <div class="panel supportersPanel" aria-label="Current subscribers">
+          <div class="supportersHead">
+            <div>
+              <h2 class="supportersTitle">CURRENT SUBSCRIBERS</h2>
+              <div class="supportersMeta">TWITCH SUPPORTERS · LIVE ROSTER</div>
+            </div>
+            <div class="supportersMeta" id="supporterCount">LOADING…</div>
+          </div>
+
+          <div class="supportersViewport">
+            <div class="supportersTrack static" id="supportersTrack">
+              <div class="supportersEmpty">Loading current subscribers…</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="miniRadar" aria-hidden="true">
+          <div class="radar-logo">
+            <span class="sweep"></span>
+          </div>
         </div>
       </div>
     </div>
@@ -567,6 +757,162 @@
         <span>${statusSets[i][2]}</span>
       `;
     }, 4200);
+
+    const trackEl = document.getElementById('supportersTrack');
+    const countEl = document.getElementById('supporterCount');
+
+    const twitchIcon = `
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 3h18v11l-5 5h-5l-3 3H6v-3H4V3zm2 2v12h3v3l3-3h6l3-3V5H6zm10 3h2v6h-2V8zm-5 0h2v6h-2V8z"/></svg>
+    `;
+
+    function escapeHtml(value) {
+      return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function tierRank(tierName) {
+      const v = String(tierName || '').toLowerCase();
+      if (v.includes('tier 3')) return 3;
+      if (v.includes('tier 2')) return 2;
+      return 1;
+    }
+
+    function sortSubscribers(items) {
+      return [...items].sort((a, b) => {
+        const tierDiff = tierRank(b.tier_name) - tierRank(a.tier_name);
+        if (tierDiff !== 0) return tierDiff;
+        return String(a.display_name || '').localeCompare(String(b.display_name || ''), undefined, { sensitivity: 'base' });
+      });
+    }
+
+    function renderRows(items) {
+      return items.map(item => {
+        const badge = item.is_gift ? 'GIFTED' : (item.tier_name || 'SUBSCRIBER').toUpperCase();
+        const subline = item.is_gift ? 'TWITCH SUBSCRIBER · GIFTED' : 'TWITCH SUBSCRIBER';
+        return `
+          <div class="supporterRow">
+            <div class="supporterIcon">${twitchIcon}</div>
+            <div class="supporterText">
+              <div class="supporterName">${escapeHtml(item.display_name || 'UNKNOWN')}</div>
+              <div class="supporterSub">${escapeHtml(subline)}</div>
+            </div>
+            <div class="supporterBadge">${escapeHtml(badge)}</div>
+          </div>
+        `;
+      }).join('');
+    }
+
+    let animationFrame = null;
+    let scrollOffset = 0;
+    let lastFrameTs = 0;
+    let currentSignature = '';
+    let currentLoopDistance = 0;
+    const scrollSpeedPxPerSec = 24;
+
+    function stopSupporterScroll() {
+      if (animationFrame) {
+        cancelAnimationFrame(animationFrame);
+        animationFrame = null;
+      }
+      lastFrameTs = 0;
+      scrollOffset = 0;
+      currentLoopDistance = 0;
+      trackEl.style.transform = 'translate3d(0, 0, 0)';
+    }
+
+    function startSupporterScroll() {
+      const firstGroup = trackEl.querySelector('.supportersGroup');
+      if (!firstGroup) return;
+
+      currentLoopDistance = firstGroup.offsetHeight + 9;
+      if (currentLoopDistance <= 0) return;
+
+      trackEl.className = 'supportersTrack scrolling';
+      trackEl.style.transform = 'translate3d(0, 0, 0)';
+      scrollOffset = 0;
+      lastFrameTs = 0;
+
+      const step = (ts) => {
+        if (!lastFrameTs) lastFrameTs = ts;
+        const delta = (ts - lastFrameTs) / 1000;
+        lastFrameTs = ts;
+
+        scrollOffset += scrollSpeedPxPerSec * delta;
+        if (scrollOffset >= currentLoopDistance) {
+          scrollOffset -= currentLoopDistance;
+        }
+
+        trackEl.style.transform = `translate3d(0, ${(-scrollOffset).toFixed(3)}px, 0)`;
+        animationFrame = requestAnimationFrame(step);
+      };
+
+      animationFrame = requestAnimationFrame(step);
+    }
+
+    function setSupporterMarkup(markup, shouldScroll) {
+      stopSupporterScroll();
+
+      if (!shouldScroll) {
+        trackEl.className = 'supportersTrack static';
+        trackEl.innerHTML = markup;
+        return;
+      }
+
+      trackEl.innerHTML = `
+        <div class="supportersGroup">${markup}</div>
+        <div class="supportersGroup" aria-hidden="true">${markup}</div>
+      `;
+
+      requestAnimationFrame(() => {
+        requestAnimationFrame(startSupporterScroll);
+      });
+    }
+
+    async function loadSupporters() {
+      try {
+        const res = await fetch('/api/supporters/recent?limit=100', { cache: 'no-store' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+
+        const twitchItems = Array.isArray(data.items)
+          ? data.items.filter(item => item && item.platform === 'twitch')
+          : [];
+
+        const ordered = sortSubscribers(twitchItems);
+        countEl.textContent = `${ordered.length} ON FILE`;
+
+        if (!ordered.length) {
+          currentSignature = '';
+          setSupporterMarkup('<div class="supportersEmpty">No Twitch subscribers are available yet.</div>', false);
+          return;
+        }
+
+        const markup = renderRows(ordered);
+        const shouldScroll = ordered.length > 8;
+        const signature = JSON.stringify(ordered.map(item => [item.id || '', item.display_name || '', item.tier_name || '', !!item.is_gift]));
+
+        if (signature === currentSignature) {
+          if (shouldScroll && !animationFrame) {
+            startSupporterScroll();
+          }
+          return;
+        }
+
+        currentSignature = signature;
+        setSupporterMarkup(markup, shouldScroll);
+      } catch (err) {
+        currentSignature = '';
+        countEl.textContent = 'UNAVAILABLE';
+        setSupporterMarkup('<div class="supportersEmpty">Unable to load current subscribers right now.</div>', false);
+      }
+    }
+
+    loadSupporters();
+    setInterval(loadSupporters, 60000);
   </script>
 </body>
 </html>

--- a/Mode-S Client/assets/overlay/portrait/26_post_stream.html
+++ b/Mode-S Client/assets/overlay/portrait/26_post_stream.html
@@ -24,9 +24,7 @@
     overflow:hidden;
   }
 
-  body{
-    display:block;
-  }
+  body{ display:block; }
 
   .stage{
     position:fixed;
@@ -103,6 +101,7 @@
     align-items:center;
     gap:16px;
     min-width:0;
+    flex:1 1 auto;
   }
 
   .badge{
@@ -118,7 +117,7 @@
     font-weight:700;
     letter-spacing:.10em;
     text-transform:uppercase;
-    font-size:15px;
+    font-size:12px;
     color:var(--text);
     white-space:nowrap;
     overflow:hidden;
@@ -156,31 +155,33 @@
     justify-content:center;
   }
 
-  .stat svg{
-    width:16px;
-    height:16px;
-    fill:var(--text);
-    opacity:.92;
-    flex:0 0 auto;
-  }
+  .stat svg{ width:16px; height:16px; fill:var(--text); opacity:.92; flex:0 0 auto; }
 
   .main{
     position:absolute;
     inset:clamp(108px, 7.1vh, 136px) clamp(24px, 2.8vw, 36px) clamp(24px, 2.8vw, 36px) clamp(24px, 2.8vw, 36px);
     display:grid;
-    grid-template-rows:auto auto 1fr auto;
-    gap:24px;
+    grid-template-rows:auto auto minmax(300px, 1fr) auto;
+    gap:16px;
     z-index:2;
+    min-height:0;
   }
 
-  .hero{
-    padding:clamp(24px, 2.4vw, 36px) clamp(24px, 2.4vw, 34px) clamp(24px, 2.4vw, 34px);
+  .hero,
+  .discordCard,
+  .platformCard,
+  .subscribersCard,
+  .footer{
     border-radius:24px;
     background:var(--panel);
     backdrop-filter:blur(8px);
     -webkit-backdrop-filter:blur(8px);
     border:1px solid var(--stroke);
-    box-shadow:0 24px 60px rgba(0,0,0,.22);
+    box-shadow:0 24px 60px rgba(0,0,0,.20);
+  }
+
+  .hero{
+    padding:20px 22px 22px;
     text-align:left;
   }
 
@@ -210,9 +211,9 @@
   }
 
   .endTitle{
-    margin:0 0 16px 0;
+    margin:0 0 12px 0;
     color:var(--text);
-    font-size:clamp(86px, 11.5vw, 124px);
+    font-size:clamp(72px, 10vw, 104px);
     line-height:.88;
     font-weight:900;
     letter-spacing:.01em;
@@ -224,7 +225,7 @@
     margin:0;
     max-width:920px;
     color:var(--muted);
-    font-size:clamp(18px, 2.2vw, 24px);
+    font-size:clamp(15px, 1.9vw, 20px);
     line-height:1.38;
     letter-spacing:.01em;
   }
@@ -232,21 +233,11 @@
   .ctaWrap{
     display:grid;
     grid-template-columns:1fr;
-    gap:24px;
-  }
-
-  .discordCard,
-  .platformCard{
-    border-radius:24px;
-    background:var(--panel);
-    backdrop-filter:blur(8px);
-    -webkit-backdrop-filter:blur(8px);
-    border:1px solid var(--stroke);
-    box-shadow:0 24px 60px rgba(0,0,0,.20);
+    gap:16px;
   }
 
   .discordCard{
-    padding:clamp(24px, 2.3vw, 34px) clamp(24px, 2.3vw, 34px) clamp(22px, 2.1vw, 32px);
+    padding:20px 22px 20px;
     position:relative;
     overflow:hidden;
     background:
@@ -310,48 +301,15 @@
     text-transform:uppercase;
   }
 
-  .discordAction svg{
-    width:28px;
-    height:28px;
-    fill:var(--text);
-    opacity:.94;
-    flex:0 0 auto;
-  }
+  .discordAction svg{ width:28px; height:28px; fill:var(--text); opacity:.94; flex:0 0 auto; }
 
-  .platformCard{
-    padding:28px;
-  }
+  .platformCard{ padding:24px; }
 
-  .platformIntro{
-    display:flex;
-    align-items:flex-end;
-    justify-content:space-between;
-    gap:20px;
-    margin-bottom:18px;
-  }
+  .platformIntro{ display:flex; align-items:flex-end; justify-content:space-between; gap:16px; margin-bottom:16px; }
+  .platformTitle{ margin:0; color:var(--text); font-size:44px; line-height:1; font-weight:900; letter-spacing:.03em; text-transform:uppercase; }
+  .platformSub{ margin:8px 0 0; color:var(--muted); font-size:20px; line-height:1.32; }
 
-  .platformTitle{
-    margin:0;
-    color:var(--text);
-    font-size:44px;
-    line-height:1;
-    font-weight:900;
-    letter-spacing:.03em;
-    text-transform:uppercase;
-  }
-
-  .platformSub{
-    margin:8px 0 0;
-    color:var(--muted);
-    font-size:20px;
-    line-height:1.32;
-  }
-
-  .platformGrid{
-    display:grid;
-    grid-template-columns:1fr;
-    gap:14px;
-  }
+  .platformGrid{ display:grid; grid-template-columns:1fr; gap:14px; }
 
   .platformItem{
     display:grid;
@@ -365,134 +323,137 @@
   }
 
   .platformIcon{
-    width:66px;
-    height:66px;
-    border-radius:18px;
-    display:grid;
-    place-items:center;
-    background:rgba(255,255,255,.08);
-    border:1px solid rgba(255,255,255,.12);
+    width:66px; height:66px; border-radius:18px; display:grid; place-items:center;
+    background:rgba(255,255,255,.08); border:1px solid rgba(255,255,255,.12);
   }
+  .platformIcon svg{ width:26px; height:26px; fill:var(--text); opacity:.96; }
+  .platformMeta{ min-width:0; }
+  .platformName{ color:var(--text); font-size:26px; font-weight:900; letter-spacing:.05em; text-transform:uppercase; line-height:1.05; }
+  .platformHandle{ margin-top:4px; color:var(--muted); font-size:20px; font-weight:700; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .platformTag{ padding:10px 12px; border-radius:999px; border:1px solid rgba(255,255,255,.12); background:rgba(255,255,255,.06); color:var(--text); font-size:13px; font-weight:900; letter-spacing:.10em; text-transform:uppercase; white-space:nowrap; }
 
-  .platformIcon svg{
-    width:26px;
-    height:26px;
-    fill:var(--text);
-    opacity:.96;
-  }
-
-  .platformMeta{
-    min-width:0;
-  }
-
-  .platformName{
-    color:var(--text);
-    font-size:26px;
-    font-weight:900;
-    letter-spacing:.05em;
-    text-transform:uppercase;
-    line-height:1.05;
-  }
-
-  .platformHandle{
-    margin-top:4px;
-    color:var(--muted);
-    font-size:20px;
-    font-weight:700;
-    white-space:nowrap;
+  .subscribersCard{
+    padding:14px 14px 12px;
+    display:flex;
+    flex-direction:column;
+    min-height:0;
     overflow:hidden;
-    text-overflow:ellipsis;
+    position:relative;
   }
 
-  .platformTag{
-    padding:10px 12px;
-    border-radius:999px;
-    border:1px solid rgba(255,255,255,.12);
-    background:rgba(255,255,255,.06);
+  .subHeader{
+    display:flex;
+    align-items:flex-end;
+    justify-content:space-between;
+    gap:16px;
+    margin-bottom:10px;
+    flex:0 0 auto;
+  }
+
+  .subscribersTitle{
+    margin:0;
     color:var(--text);
-    font-size:13px;
+    font-size:28px;
+    line-height:.94;
     font-weight:900;
-    letter-spacing:.10em;
+    letter-spacing:.04em;
+    text-transform:uppercase;
+  }
+
+  .subscribersSub{
+    margin:5px 0 0;
+    color:var(--muted);
+    font-size:12px;
+    font-weight:800;
+    letter-spacing:.12em;
+    text-transform:uppercase;
+  }
+
+  .subscribersCount{
+    color:var(--muted);
+    font-size:12px;
+    font-weight:900;
+    letter-spacing:.14em;
     text-transform:uppercase;
     white-space:nowrap;
+  }
+
+  .subViewport{
+    position:relative;
+    min-height:220px;
+    flex:1 1 auto;
+    min-height:0;
+    overflow:hidden;
+    border-radius:20px;
+    background:rgba(10,14,18,.28);
+    border:1px solid rgba(255,255,255,.10);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.04);
+  }
+
+  .subViewport::before,
+  .subViewport::after{
+    content:"";
+    position:absolute;
+    left:0; right:0;
+    height:28px;
+    z-index:2;
+    pointer-events:none;
+  }
+  .subViewport::before{ top:0; background:linear-gradient(180deg, rgba(16,20,26,.92), rgba(16,20,26,0)); }
+  .subViewport::after{ bottom:0; background:linear-gradient(0deg, rgba(16,20,26,.96), rgba(16,20,26,0)); }
+
+  .subTrack{ position:absolute; left:0; right:0; top:0; will-change:transform; }
+  .subGroup{ display:flex; flex-direction:column; gap:8px; padding:10px; }
+
+  .subRow{
+    display:grid;
+    grid-template-columns:50px 1fr auto;
+    align-items:center;
+    gap:14px;
+    min-height:56px;
+    padding:8px 10px;
+    border-radius:18px;
+    background:rgba(255,255,255,.03);
+    border:1px solid rgba(255,255,255,.09);
+  }
+
+  .subIcon{
+    width:36px; height:36px; border-radius:16px; display:grid; place-items:center;
+    background:rgba(30,109,255,.16); border:1px solid rgba(255,255,255,.12);
+  }
+  .subIcon svg{ width:16px; height:16px; fill:var(--text); opacity:.96; }
+
+  .subMeta{ min-width:0; }
+  .subName{ color:var(--text); font-size:14px; font-weight:900; line-height:1.06; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .subType{ margin-top:2px; color:var(--muted); font-size:10px; font-weight:800; letter-spacing:.12em; text-transform:uppercase; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .subBadge{ padding:6px 8px; border-radius:999px; border:1px solid rgba(255,255,255,.12); background:rgba(255,255,255,.06); color:var(--text); font-size:10px; font-weight:900; letter-spacing:.08em; text-transform:uppercase; white-space:nowrap; }
+
+  .subEmpty{
+    height:100%; display:grid; place-items:center; padding:22px; text-align:center; color:var(--muted);
+    font-size:14px; line-height:1.45;
   }
 
   .footer{
     display:flex;
     align-items:center;
     justify-content:space-between;
-    gap:16px;
-    padding:24px 26px;
-    border-radius:22px;
+    gap:12px;
+    padding:14px 18px;
     background:var(--panel-strong);
-    border:1px solid var(--stroke);
     color:var(--text);
   }
 
-  .footerLeft{
-    display:flex;
-    align-items:center;
-    gap:14px;
-    min-width:0;
-  }
+  .footerLeft{ display:flex; align-items:center; gap:14px; min-width:0; }
+  .footerLeft svg{ width:30px; height:30px; fill:var(--text); opacity:.95; flex:0 0 auto; }
+  .footerText{ min-width:0; }
+  .footerTitle{ font-size:14px; font-weight:900; letter-spacing:.08em; text-transform:uppercase; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .footerSub{ margin-top:3px; color:var(--muted); font-size:12px; letter-spacing:.04em; }
+  .footerRight{ text-align:right; flex:0 0 auto; }
+  .site{ font-size:26px; font-weight:900; letter-spacing:.10em; text-transform:uppercase; }
+  .offline{ margin-top:2px; color:var(--muted); font-size:10px; letter-spacing:.18em; text-transform:uppercase; }
 
-  .footerLeft svg{
-    width:30px;
-    height:30px;
-    fill:var(--text);
-    opacity:.95;
-    flex:0 0 auto;
-  }
-
-  .footerText{
-    min-width:0;
-  }
-
-  .footerTitle{
-    font-size:18px;
-    font-weight:900;
-    letter-spacing:.08em;
-    text-transform:uppercase;
-    white-space:nowrap;
-    overflow:hidden;
-    text-overflow:ellipsis;
-  }
-
-  .footerSub{
-    margin-top:3px;
-    color:var(--muted);
-    font-size:15px;
-    letter-spacing:.04em;
-  }
-
-  .footerRight{
-    text-align:right;
-    flex:0 0 auto;
-  }
-
-  .site{
-    font-size:26px;
-    font-weight:900;
-    letter-spacing:.10em;
-    text-transform:uppercase;
-  }
-
-  .offline{
-    margin-top:4px;
-    color:var(--muted);
-    font-size:14px;
-    letter-spacing:.18em;
-    text-transform:uppercase;
-  }
-
-  .pulse{
-    animation:pulse 2.6s ease-in-out infinite;
-  }
-
-  @keyframes pulse{
-    0%,100%{ transform:scale(1); opacity:.94; }
-    50%{ transform:scale(1.018); opacity:1; }
-  }
+  .pulse{ animation:pulse 2.6s ease-in-out infinite; }
+  @keyframes pulse{ 0%,100%{ transform:scale(1); opacity:.94; } 50%{ transform:scale(1.018); opacity:1; } }
 
   @media (max-width: 1080px), (max-height: 1920px){
     .stage{
@@ -500,7 +461,6 @@
       height:min(100vh, calc(100vw * 1920 / 1080));
     }
   }
-
   </style>
 </head>
 <body>
@@ -562,46 +522,41 @@
 
           <div class="platformGrid">
             <div class="platformItem">
-              <div class="platformIcon">
-                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 3h18v11l-5 5h-5l-3 3H6v-3H4V3zm2 2v12h3v3l3-3h6l3-3V5H6zm10 3h2v6h-2V8zm-5 0h2v6h-2V8z"/></svg>
-              </div>
-              <div class="platformMeta">
-                <div class="platformName">Twitch</div>
-                <div class="platformHandle">RADARCONTROLLER</div>
-              </div>
+              <div class="platformIcon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 3h18v11l-5 5h-5l-3 3H6v-3H4V3zm2 2v12h3v3l3-3h6l3-3V5H6zm10 3h2v6h-2V8zm-5 0h2v6h-2V8z"/></svg></div>
+              <div class="platformMeta"><div class="platformName">Twitch</div><div class="platformHandle">RADARCONTROLLER</div></div>
               <div class="platformTag">Live streams</div>
             </div>
-
             <div class="platformItem">
-              <div class="platformIcon">
-                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21.6 7.2c-.2-1-1-1.8-2-2C17.8 4.8 12 4.8 12 4.8s-5.8 0-7.6.4c-1 .2-1.8 1-2 2C2 9 2 12 2 12s0 3 .4 4.8c.2 1 1 1.8 2 2 1.8.4 7.6.4 7.6.4s5.8 0 7.6-.4c1-.2 1.8-1 2-2 .4-1.8.4-4.8.4-4.8s0-3-.4-4.8zM10 15.5v-7l6 3.5-6 3.5z"/></svg>
-              </div>
-              <div class="platformMeta">
-                <div class="platformName">YouTube</div>
-                <div class="platformHandle">@RADARCONTROLLER</div>
-              </div>
-              <div class="platformTag">Videos & VODs</div>
+              <div class="platformIcon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21.6 7.2c-.2-1-1-1.8-2-2C17.8 4.8 12 4.8 12 4.8s-5.8 0-7.6.4c-1 .2-1.8-1-2 2C2 9 2 12 2 12s0 3 .4 4.8c.2 1 1 1.8 2 2 1.8.4 7.6.4 7.6.4s5.8 0 7.6-.4c1-.2 1.8-1 2-2 .4-1.8.4-4.8.4-4.8s0-3-.4-4.8zM10 15.5v-7l6 3.5-6 3.5z"/></svg></div>
+              <div class="platformMeta"><div class="platformName">YouTube</div><div class="platformHandle">@RADARCONTROLLER</div></div>
+              <div class="platformTag">Videos &amp; VODs</div>
             </div>
-
             <div class="platformItem">
-              <div class="platformIcon">
-                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 3c.6 3.4 2.6 5.4 6 5.9V12c-2.3-.1-4.3-.9-6-2.4V16c0 4-3.1 7-7.1 7C5 23 2 19.9 2 16.1 2 12.3 5.1 9.2 8.9 9.2c.5 0 1 .1 1.5.2v3.8c-.4-.2-.9-.4-1.5-.4-1.8 0-3.1 1.4-3.1 3.3 0 1.9 1.4 3.3 3.2 3.3 1.8 0 3.5-1.2 3.5-4V3h3z"/></svg>
-              </div>
-              <div class="platformMeta">
-                <div class="platformName">TikTok</div>
-                <div class="platformHandle">@RADARCONTROLLER</div>
-              </div>
-              <div class="platformTag">Clips & live</div>
+              <div class="platformIcon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 3c.6 3.4 2.6 5.4 6 5.9V12c-2.3-.1-4.3-.9-6-2.4V16c0 4-3.1 7-7.1 7C5 23 2 19.9 2 16.1 2 12.3 5.1 9.2 8.9 9.2c.5 0 1 .1 1.5.2v3.8c-.4-.2-.9-.4-1.5-.4-1.8 0-3.1 1.4-3.1 3.3 0 1.9 1.4 3.3 3.2 3.3 1.8 0 3.5-1.2 3.5-4V3h3z"/></svg></div>
+              <div class="platformMeta"><div class="platformName">TikTok</div><div class="platformHandle">@RADARCONTROLLER</div></div>
+              <div class="platformTag">Clips &amp; live</div>
             </div>
           </div>
         </div>
       </section>
 
+      <section class="subscribersCard">
+        <div class="subHeader">
+          <div>
+            <h2 class="subscribersTitle">CURRENT SUBSCRIBERS</h2>
+            <div class="subscribersSub">Twitch supporters • live roster</div>
+          </div>
+          <div class="subscribersCount" id="subCount">Loading…</div>
+        </div>
+        <div class="subViewport" id="subViewport">
+          <div class="subTrack" id="subTrack"></div>
+          <div class="subEmpty" id="subEmpty" hidden></div>
+        </div>
+      </section>
+
       <footer class="footer">
         <div class="footerLeft">
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M7 9h10a5 5 0 0 1 5 5v1a5 5 0 0 1-5 5h-2l-2-2H11l-2 2H7a5 5 0 0 1-5-5v-1a5 5 0 0 1 5-5zm2.2 5.2h-1.4V13H6.6v1.4H5.2v1.2h1.4V17h1.2v-1.4h1.4v-1.2zm9.2-.2a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm-2.6 2a1 1 0 1 0 0 2 1 1 0 0 0 0-2z"/>
-          </svg>
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 9h10a5 5 0 0 1 5 5v1a5 5 0 0 1-5 5h-2l-2-2H11l-2 2H7a5 5 0 0 1-5-5v-1a5 5 0 0 1 5-5zm2.2 5.2h-1.4V13H6.6v1.4H5.2v1.2h1.4V17h1.2v-1.4h1.4v-1.2zm9.2-.2a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm-2.6 2a1 1 0 1 0 0 2 1 1 0 0 0 0-2z"/></svg>
           <div class="footerText">
             <div class="footerTitle">Thanks for watching</div>
             <div class="footerSub">Follow the channels. Join the server. Catch the next stream.</div>
@@ -614,5 +569,152 @@
       </footer>
     </div>
   </div>
+
+  <script>
+    const ENDPOINT = '/api/supporters/recent?limit=100';
+    const track = document.getElementById('subTrack');
+    const empty = document.getElementById('subEmpty');
+    const count = document.getElementById('subCount');
+    const viewport = document.getElementById('subViewport');
+
+    let animationFrame = null;
+    let scrollOffset = 0;
+    let loopHeight = 0;
+    let speed = 0.08;
+    let lastTs = 0;
+    let currentSignature = '';
+
+    function tierWeight(value) {
+      const v = String(value || '').toUpperCase();
+      if (v.includes('TIER 3')) return 0;
+      if (v.includes('TIER 2')) return 1;
+      if (v.includes('TIER 1')) return 2;
+      if (v.includes('GIFT')) return 3;
+      return 4;
+    }
+
+    function typeLine(item) {
+      const bits = ['Twitch subscriber'];
+      if (item.is_renewal) bits.push('renewal');
+      if (item.is_gift) bits.push('gifted');
+      return bits.join(' • ');
+    }
+
+    function badgeText(item) {
+      if (item.tier_name && item.tier_name.trim()) return item.tier_name.trim();
+      if (item.is_gift) return 'Gifted';
+      return 'Supporter';
+    }
+
+    function escapeHtml(value) {
+      return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function rowMarkup(item) {
+      return `
+        <div class="subRow">
+          <div class="subIcon">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 3h18v11l-5 5h-5l-3 3H6v-3H4V3zm2 2v12h3v3l3-3h6l3-3V5H6zm10 3h2v6h-2V8zm-5 0h2v6h-2V8z"/></svg>
+          </div>
+          <div class="subMeta">
+            <div class="subName">${escapeHtml(item.display_name || 'Unknown')}</div>
+            <div class="subType">${escapeHtml(typeLine(item))}</div>
+          </div>
+          <div class="subBadge">${escapeHtml(badgeText(item))}</div>
+        </div>`;
+    }
+
+    function stopScroll() {
+      if (animationFrame) cancelAnimationFrame(animationFrame);
+      animationFrame = null;
+      lastTs = 0;
+      scrollOffset = 0;
+      if (track) track.style.transform = 'translateY(0px)';
+    }
+
+    function startScroll() {
+      stopScroll();
+      if (!loopHeight || loopHeight <= viewport.clientHeight + 4) {
+        track.style.transform = 'translateY(0px)';
+        return;
+      }
+
+      function frame(ts) {
+        if (!lastTs) lastTs = ts;
+        const dt = Math.min(32, ts - lastTs);
+        lastTs = ts;
+        scrollOffset += speed * dt;
+        if (scrollOffset >= loopHeight) scrollOffset -= loopHeight;
+        track.style.transform = `translateY(${-scrollOffset}px)`;
+        animationFrame = requestAnimationFrame(frame);
+      }
+      animationFrame = requestAnimationFrame(frame);
+    }
+
+    function render(items) {
+      const sorted = [...items].sort((a, b) => {
+        const tw = tierWeight(a.tier_name) - tierWeight(b.tier_name);
+        if (tw !== 0) return tw;
+        return String(a.display_name || '').localeCompare(String(b.display_name || ''), undefined, { sensitivity: 'base' });
+      });
+
+      count.textContent = `${sorted.length} on file`;
+
+      if (!sorted.length) {
+        stopScroll();
+        track.innerHTML = '';
+        empty.hidden = false;
+        return;
+      }
+
+      empty.hidden = true;
+      const signature = JSON.stringify(sorted.map(x => [x.id, x.display_name, x.tier_name, x.is_gift, x.is_renewal]));
+      if (signature === currentSignature && track.children.length) return;
+      currentSignature = signature;
+
+      const listHtml = sorted.map(rowMarkup).join('');
+      track.innerHTML = `<div class="subGroup" id="subGroupA">${listHtml}</div><div class="subGroup" aria-hidden="true">${listHtml}</div>`;
+
+      requestAnimationFrame(() => {
+        const groupA = document.getElementById('subGroupA');
+        loopHeight = groupA ? groupA.offsetHeight : 0;
+        startScroll();
+      });
+    }
+
+    async function loadSubscribers() {
+      try {
+        const res = await fetch(ENDPOINT, { cache: 'no-store' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        const items = Array.isArray(data.items) ? data.items : [];
+        const twitchOnly = items.filter(item => String(item.platform || '').toLowerCase() === 'twitch');
+        render(twitchOnly);
+      } catch (err) {
+        count.textContent = 'Unavailable';
+        stopScroll();
+        track.innerHTML = '';
+        empty.hidden = false;
+        empty.textContent = '';
+      }
+    }
+
+    loadSubscribers();
+    setInterval(loadSubscribers, 45000);
+    window.addEventListener('resize', () => requestAnimationFrame(startScroll));
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        if (animationFrame) cancelAnimationFrame(animationFrame);
+        animationFrame = null;
+      } else {
+        startScroll();
+      }
+    });
+  </script>
 </body>
 </html>

--- a/Mode-S Client/integrations/twitch/TwitchSupporterProvider.cpp
+++ b/Mode-S Client/integrations/twitch/TwitchSupporterProvider.cpp
@@ -1,0 +1,282 @@
+#include "twitch/TwitchSupporterProvider.h"
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <winhttp.h>
+#pragma comment(lib, "winhttp.lib")
+
+#include <algorithm>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "json.hpp"
+#include "AppState.h"
+
+using json = nlohmann::json;
+
+namespace {
+
+std::wstring ToW(const std::string& s) {
+    if (s.empty()) return L"";
+    int len = MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()), nullptr, 0);
+    if (len <= 0) return L"";
+    std::wstring w(static_cast<size_t>(len), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()), w.data(), len);
+    return w;
+}
+
+void SafeLog(const std::function<void(const std::wstring&)>& log, const std::wstring& msg) {
+    if (!log) return;
+    try { log(msg); } catch (...) {}
+}
+
+std::string UrlEncode(const std::string& s) {
+    static const char hex[] = "0123456789ABCDEF";
+    std::string out;
+    out.reserve(s.size() * 3);
+    for (unsigned char c : s) {
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+            c == '-' || c == '_' || c == '.' || c == '~') {
+            out.push_back(static_cast<char>(c));
+        } else {
+            out.push_back('%');
+            out.push_back(hex[(c >> 4) & 0x0F]);
+            out.push_back(hex[c & 0x0F]);
+        }
+    }
+    return out;
+}
+
+struct HttpResult {
+    int status = 0;
+    DWORD winerr = 0;
+    std::string body;
+};
+
+struct WinHttpHandle {
+    HINTERNET h = nullptr;
+    WinHttpHandle() = default;
+    explicit WinHttpHandle(HINTERNET v) : h(v) {}
+    ~WinHttpHandle() { if (h) WinHttpCloseHandle(h); }
+    WinHttpHandle(const WinHttpHandle&) = delete;
+    WinHttpHandle& operator=(const WinHttpHandle&) = delete;
+    operator HINTERNET() const { return h; }
+    bool valid() const { return h != nullptr; }
+};
+
+HttpResult WinHttpGet(const std::wstring& host,
+                      INTERNET_PORT port,
+                      const std::wstring& path,
+                      const std::wstring& extra_headers,
+                      bool secure) {
+    HttpResult r;
+    WinHttpHandle session(WinHttpOpen(L"ModeSClient/1.0", WINHTTP_ACCESS_TYPE_NO_PROXY,
+                                      WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0));
+    if (!session.valid()) { r.winerr = GetLastError(); return r; }
+
+    WinHttpSetTimeouts(session, 5000, 5000, 8000, 8000);
+    WinHttpHandle connect(WinHttpConnect(session, host.c_str(), port, 0));
+    if (!connect.valid()) { r.winerr = GetLastError(); return r; }
+
+    DWORD flags = secure ? WINHTTP_FLAG_SECURE : 0;
+    WinHttpHandle request(WinHttpOpenRequest(connect, L"GET", path.c_str(), nullptr,
+                                             WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, flags));
+    if (!request.valid()) { r.winerr = GetLastError(); return r; }
+
+    const std::wstring base_headers =
+        L"Accept: application/json\r\n"
+        L"Accept-Encoding: identity\r\n"
+        L"Connection: close\r\n";
+    WinHttpAddRequestHeaders(request, base_headers.c_str(), static_cast<ULONG>(-1), WINHTTP_ADDREQ_FLAG_ADD);
+    if (!extra_headers.empty()) {
+        WinHttpAddRequestHeaders(request, extra_headers.c_str(), static_cast<ULONG>(-1), WINHTTP_ADDREQ_FLAG_ADD);
+    }
+
+    BOOL ok = WinHttpSendRequest(request, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+                                 WINHTTP_NO_REQUEST_DATA, 0, 0, 0);
+    if (!ok) { r.winerr = GetLastError(); return r; }
+
+    ok = WinHttpReceiveResponse(request, nullptr);
+    if (!ok) { r.winerr = GetLastError(); return r; }
+
+    DWORD status = 0; DWORD status_size = sizeof(status);
+    if (WinHttpQueryHeaders(request, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                            WINHTTP_HEADER_NAME_BY_INDEX, &status, &status_size, WINHTTP_NO_HEADER_INDEX)) {
+        r.status = static_cast<int>(status);
+    }
+
+    std::string out;
+    for (;;) {
+        DWORD avail = 0;
+        if (!WinHttpQueryDataAvailable(request, &avail)) { r.winerr = GetLastError(); break; }
+        if (avail == 0) break;
+        const size_t cur = out.size();
+        out.resize(cur + static_cast<size_t>(avail));
+        DWORD read = 0;
+        if (!WinHttpReadData(request, out.data() + cur, avail, &read)) { r.winerr = GetLastError(); break; }
+        out.resize(cur + static_cast<size_t>(read));
+    }
+
+    r.body = std::move(out);
+    return r;
+}
+
+std::string JsonString(const json& j, const char* key) {
+    auto it = j.find(key);
+    if (it == j.end()) return {};
+    if (it->is_string()) return it->get<std::string>();
+    if (it->is_number_integer()) return std::to_string(it->get<long long>());
+    return {};
+}
+
+std::int64_t JsonInt64(const json& j, const char* key) {
+    auto it = j.find(key);
+    if (it == j.end()) return 0;
+    if (it->is_number_integer()) return it->get<std::int64_t>();
+    if (it->is_string()) {
+        try { return std::stoll(it->get<std::string>()); } catch (...) { return 0; }
+    }
+    return 0;
+}
+
+std::string NiceTier(const std::string& tier) {
+    if (tier == "1000") return "Tier 1";
+    if (tier == "2000") return "Tier 2";
+    if (tier == "3000") return "Tier 3";
+    return tier;
+}
+
+} // namespace
+
+namespace twitch {
+
+TwitchSupporterProvider::TwitchSupporterProvider(AppState& state,
+                                                 std::string login,
+                                                 AccessTokenFn access_token,
+                                                 std::function<std::optional<std::string>()> client_id,
+                                                 LogFn log)
+    : state_(state)
+    , login_(std::move(login))
+    , access_token_(std::move(access_token))
+    , client_id_(std::move(client_id))
+    , log_(std::move(log)) {
+}
+
+supporter::FetchResult TwitchSupporterProvider::FetchRecent(int limit) const {
+    supporter::FetchResult out;
+    if (limit <= 0) limit = 16;
+
+    const auto token = access_token_ ? access_token_() : std::nullopt;
+    if (login_.empty()) {
+        out.status.error = "twitch login not configured";
+        return out;
+    }
+    if (!token.has_value() || token->empty()) {
+        out.status.error = "twitch access token unavailable";
+        return out;
+    }
+
+    out.status.connected = true;
+
+    std::unordered_set<std::string> seen_ids;
+
+    try {
+        const json evs = state_.twitch_eventsub_events_json(200);
+        auto it = evs.find("events");
+        if (it != evs.end() && it->is_array()) {
+            for (auto rit = it->rbegin(); rit != it->rend(); ++rit) {
+                const auto& ev = *rit;
+                const std::string type = JsonString(ev, "type");
+                if (type != "channel.subscribe" && type != "channel.subscription.message" && type != "channel.subscription.gift") {
+                    continue;
+                }
+
+                supporter::RecentSupporter item;
+                item.platform = "twitch";
+                item.display_name = JsonString(ev, "user");
+                if (item.display_name.empty()) continue;
+                item.id = "eventsub:" + item.display_name + ":" + std::to_string(JsonInt64(ev, "ts_ms"));
+                item.supported_at_ms = JsonInt64(ev, "ts_ms");
+                item.support_type = "subscriber";
+                item.is_gift = (type == "channel.subscription.gift");
+                item.is_renewal = (type == "channel.subscription.message");
+                if (seen_ids.insert(item.id).second) {
+                    out.items.push_back(std::move(item));
+                    if (static_cast<int>(out.items.size()) >= limit) break;
+                }
+            }
+        }
+    } catch (...) {
+        SafeLog(log_, L"[Supporters][Twitch] Failed to read EventSub cache");
+    }
+
+    // Use the Helix endpoint only as a fallback/source of current subscribers.
+    // Twitch subscriber rows do not give a strong recent-event timestamp, so these are intentionally
+    // given supported_at_ms=0 and will sort behind EventSub-backed items.
+    const auto client_id_opt = client_id_ ? client_id_() : std::nullopt;
+    const std::string client_id = client_id_opt.value_or("");
+
+    if (client_id.empty()) {
+        // No reliable client id accessor is wired into this provider yet. We can still return EventSub-backed items.
+        out.status.ok = out.status.error.empty();
+        out.status.item_count = static_cast<int>(out.items.size());
+        if (out.items.empty()) {
+            out.status.error = "twitch client id unavailable for Helix subscriber fallback";
+        }
+        return out;
+    }
+
+    std::wstring headers = L"Authorization: Bearer " + ToW(*token) + L"\r\nClient-Id: " + ToW(client_id) + L"\r\n";
+
+    std::string broadcaster_id;
+    {
+        const std::string user_path = "/helix/users?login=" + UrlEncode(login_);
+        HttpResult user_res = WinHttpGet(L"api.twitch.tv", INTERNET_DEFAULT_HTTPS_PORT, ToW(user_path), headers, true);
+        if (user_res.status >= 200 && user_res.status < 300) {
+            try {
+                json j = json::parse(user_res.body);
+                if (j.contains("data") && j["data"].is_array() && !j["data"].empty()) {
+                    broadcaster_id = j["data"][0].value("id", std::string{});
+                }
+            } catch (...) {}
+        }
+    }
+
+    if (!broadcaster_id.empty() && static_cast<int>(out.items.size()) < limit) {
+        const std::string subs_path = "/helix/subscriptions?broadcaster_id=" + UrlEncode(broadcaster_id) + "&first=" + std::to_string(limit);
+        HttpResult subs_res = WinHttpGet(L"api.twitch.tv", INTERNET_DEFAULT_HTTPS_PORT, ToW(subs_path), headers, true);
+        if (subs_res.status >= 200 && subs_res.status < 300) {
+            try {
+                json j = json::parse(subs_res.body);
+                if (j.contains("data") && j["data"].is_array()) {
+                    for (const auto& row : j["data"]) {
+                        supporter::RecentSupporter item;
+                        item.platform = "twitch";
+                        item.id = row.value("user_id", std::string{});
+                        item.display_name = row.value("user_name", row.value("user_login", std::string{}));
+                        item.supported_at_ms = 0;
+                        item.support_type = "subscriber";
+                        item.tier_name = NiceTier(row.value("tier", std::string{}));
+                        item.is_gift = row.value("is_gift", false);
+                        if (item.display_name.empty()) continue;
+                        if (!item.id.empty() && !seen_ids.insert("helix:" + item.id).second) continue;
+                        out.items.push_back(std::move(item));
+                        if (static_cast<int>(out.items.size()) >= limit) break;
+                    }
+                }
+            } catch (...) {
+                SafeLog(log_, L"[Supporters][Twitch] Failed to parse Helix subscriptions response");
+            }
+        } else if (out.items.empty()) {
+            out.status.error = "twitch subscriptions request failed";
+        }
+    }
+
+    out.status.ok = out.status.error.empty();
+    out.status.item_count = static_cast<int>(out.items.size());
+    return out;
+}
+
+} // namespace twitch

--- a/Mode-S Client/integrations/twitch/TwitchSupporterProvider.h
+++ b/Mode-S Client/integrations/twitch/TwitchSupporterProvider.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+
+#include "supporter/RecentSupporter.h"
+
+class AppState;
+
+namespace twitch {
+
+class TwitchSupporterProvider {
+public:
+    using AccessTokenFn = std::function<std::optional<std::string>()>;
+    using LogFn = std::function<void(const std::wstring&)>;
+
+    TwitchSupporterProvider(AppState& state,
+                            std::string login,
+                            AccessTokenFn access_token,
+                            std::function<std::optional<std::string>()> client_id,
+                            LogFn log);
+
+    supporter::FetchResult FetchRecent(int limit) const;
+
+private:
+    AppState& state_;
+    std::string login_;
+    AccessTokenFn access_token_;
+    std::function<std::optional<std::string>()> client_id_;
+    LogFn log_;
+};
+
+} // namespace twitch

--- a/Mode-S Client/integrations/youtube/YouTubeAuth.cpp
+++ b/Mode-S Client/integrations/youtube/YouTubeAuth.cpp
@@ -106,11 +106,13 @@ void YouTubeAuth::LogUi(const std::string& msg) {
 // ---- scopes ----
 const char* YouTubeAuth::RequiredScopeReadable() {
     // Minimum required for updating YouTube metadata (videos.update, liveBroadcasts.update, etc.)
-    return "youtube.force-ssl";
+    return "https://www.googleapis.com/auth/youtube.force-ssl "
+        "https://www.googleapis.com/auth/youtube.channel-memberships.creator";
 }
 const char* YouTubeAuth::RequiredScopeEncoded() {
     // URL-encoded space-delimited scopes. (Single scope here.)
-    return "https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.force-ssl";
+    return "https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.force-ssl%20"
+        "https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.channel-memberships.creator";
 }
 
 // ---- lifecycle ----

--- a/Mode-S Client/integrations/youtube/YouTubeAuth.h
+++ b/Mode-S Client/integrations/youtube/YouTubeAuth.h
@@ -72,8 +72,10 @@ public:
         const std::string& refresh_token,
         const std::string& channel_id)> on_tokens_updated;
 
-    // Minimal scope set for updating YouTube metadata.
-    // (If you later need more, update these and re-auth.)
+    // Scope set required for current YouTube features:
+    // - youtube.force-ssl for existing YouTube Data API usage
+    // - youtube.channel-memberships.creator for channel member reads
+    // If more scopes are added later, re-auth will be required.
     static const char* RequiredScopeEncoded();
     static const char* RequiredScopeReadable();
 

--- a/Mode-S Client/integrations/youtube/YouTubeSupporterProvider.cpp
+++ b/Mode-S Client/integrations/youtube/YouTubeSupporterProvider.cpp
@@ -1,0 +1,243 @@
+#include "youtube/YouTubeSupporterProvider.h"
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <winhttp.h>
+#pragma comment(lib, "winhttp.lib")
+
+#include <algorithm>
+#include <ctime>
+#include <utility>
+
+#include "json.hpp"
+
+using json = nlohmann::json;
+
+namespace {
+
+std::wstring ToW(const std::string& s) {
+    if (s.empty()) return L"";
+    int len = MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()), nullptr, 0);
+    if (len <= 0) return L"";
+    std::wstring w(static_cast<size_t>(len), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()), w.data(), len);
+    return w;
+}
+
+void SafeLog(const std::function<void(const std::wstring&)>& log, const std::wstring& msg) {
+    if (!log) return;
+    try { log(msg); } catch (...) {}
+}
+
+std::string UrlEncode(const std::string& s) {
+    static const char hex[] = "0123456789ABCDEF";
+    std::string out;
+    out.reserve(s.size() * 3);
+    for (unsigned char c : s) {
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+            c == '-' || c == '_' || c == '.' || c == '~') {
+            out.push_back(static_cast<char>(c));
+        } else {
+            out.push_back('%');
+            out.push_back(hex[(c >> 4) & 0x0F]);
+            out.push_back(hex[c & 0x0F]);
+        }
+    }
+    return out;
+}
+
+struct HttpResult {
+    int status = 0;
+    DWORD winerr = 0;
+    std::string body;
+};
+
+struct WinHttpHandle {
+    HINTERNET h = nullptr;
+    WinHttpHandle() = default;
+    explicit WinHttpHandle(HINTERNET v) : h(v) {}
+    ~WinHttpHandle() { if (h) WinHttpCloseHandle(h); }
+    WinHttpHandle(const WinHttpHandle&) = delete;
+    WinHttpHandle& operator=(const WinHttpHandle&) = delete;
+    operator HINTERNET() const { return h; }
+    bool valid() const { return h != nullptr; }
+};
+
+HttpResult WinHttpGet(const std::wstring& host,
+                      INTERNET_PORT port,
+                      const std::wstring& path,
+                      const std::wstring& extra_headers,
+                      bool secure) {
+    HttpResult r;
+    WinHttpHandle session(WinHttpOpen(L"ModeSClient/1.0", WINHTTP_ACCESS_TYPE_NO_PROXY,
+                                      WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0));
+    if (!session.valid()) { r.winerr = GetLastError(); return r; }
+
+    WinHttpSetTimeouts(session, 5000, 5000, 8000, 8000);
+    WinHttpHandle connect(WinHttpConnect(session, host.c_str(), port, 0));
+    if (!connect.valid()) { r.winerr = GetLastError(); return r; }
+
+    DWORD flags = secure ? WINHTTP_FLAG_SECURE : 0;
+    WinHttpHandle request(WinHttpOpenRequest(connect, L"GET", path.c_str(), nullptr,
+                                             WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, flags));
+    if (!request.valid()) { r.winerr = GetLastError(); return r; }
+
+    const std::wstring base_headers =
+        L"Accept: application/json\r\n"
+        L"Accept-Encoding: identity\r\n"
+        L"Connection: close\r\n";
+    WinHttpAddRequestHeaders(request, base_headers.c_str(), static_cast<ULONG>(-1), WINHTTP_ADDREQ_FLAG_ADD);
+    if (!extra_headers.empty()) {
+        WinHttpAddRequestHeaders(request, extra_headers.c_str(), static_cast<ULONG>(-1), WINHTTP_ADDREQ_FLAG_ADD);
+    }
+
+    BOOL ok = WinHttpSendRequest(request, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+                                 WINHTTP_NO_REQUEST_DATA, 0, 0, 0);
+    if (!ok) { r.winerr = GetLastError(); return r; }
+
+    ok = WinHttpReceiveResponse(request, nullptr);
+    if (!ok) { r.winerr = GetLastError(); return r; }
+
+    DWORD status = 0; DWORD status_size = sizeof(status);
+    if (WinHttpQueryHeaders(request, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                            WINHTTP_HEADER_NAME_BY_INDEX, &status, &status_size, WINHTTP_NO_HEADER_INDEX)) {
+        r.status = static_cast<int>(status);
+    }
+
+    std::string out;
+    for (;;) {
+        DWORD avail = 0;
+        if (!WinHttpQueryDataAvailable(request, &avail)) { r.winerr = GetLastError(); break; }
+        if (avail == 0) break;
+        const size_t cur = out.size();
+        out.resize(cur + static_cast<size_t>(avail));
+        DWORD read = 0;
+        if (!WinHttpReadData(request, out.data() + cur, avail, &read)) { r.winerr = GetLastError(); break; }
+        out.resize(cur + static_cast<size_t>(read));
+    }
+
+    r.body = std::move(out);
+    return r;
+}
+
+std::int64_t ParseIsoToEpochMs(const std::string& iso) {
+    if (iso.size() < 19) return 0;
+    std::tm tm{};
+    try {
+        tm.tm_year = std::stoi(iso.substr(0, 4)) - 1900;
+        tm.tm_mon = std::stoi(iso.substr(5, 2)) - 1;
+        tm.tm_mday = std::stoi(iso.substr(8, 2));
+        tm.tm_hour = std::stoi(iso.substr(11, 2));
+        tm.tm_min = std::stoi(iso.substr(14, 2));
+        tm.tm_sec = std::stoi(iso.substr(17, 2));
+    } catch (...) {
+        return 0;
+    }
+#ifdef _WIN32
+    const __time64_t sec = _mkgmtime64(&tm);
+    if (sec < 0) return 0;
+    return static_cast<std::int64_t>(sec) * 1000;
+#else
+    const std::time_t sec = timegm(&tm);
+    if (sec < 0) return 0;
+    return static_cast<std::int64_t>(sec) * 1000;
+#endif
+}
+
+std::string JsonString(const json& j, const char* key) {
+    auto it = j.find(key);
+    if (it == j.end()) return {};
+    if (it->is_string()) return it->get<std::string>();
+    return {};
+}
+
+} // namespace
+
+namespace youtube {
+
+YouTubeSupporterProvider::YouTubeSupporterProvider(AccessTokenFn access_token,
+                                                   StringFn channel_id,
+                                                   LogFn log)
+    : access_token_(std::move(access_token))
+    , channel_id_(std::move(channel_id))
+    , log_(std::move(log)) {
+}
+
+supporter::FetchResult YouTubeSupporterProvider::FetchRecent(int limit) const {
+    supporter::FetchResult out;
+    if (limit <= 0) limit = 16;
+    if (limit > 50) limit = 50;
+
+    const auto token = access_token_ ? access_token_() : std::nullopt;
+
+    if (!token.has_value() || token->empty()) {
+        out.status.error = "youtube access token unavailable";
+        return out;
+    }
+
+    out.status.connected = true;
+
+    std::wstring headers;
+    headers += L"Authorization: Bearer " + ToW(*token) + L"\r\n";
+    const std::string path = "/youtube/v3/members?part=snippet&mode=all_current&maxResults=" +
+        std::to_string(limit);
+
+    HttpResult res = WinHttpGet(L"www.googleapis.com", INTERNET_DEFAULT_HTTPS_PORT, ToW(path), headers, true);
+    if (res.status < 200 || res.status >= 300) {
+        std::string body = res.body;
+        if (body.size() > 400) body.resize(400);
+
+        out.status.error = "youtube members.list request failed: HTTP " +
+            std::to_string(res.status) + ": " + body;
+
+        SafeLog(log_, L"[Supporters][YouTube] members.list failed with HTTP " +
+            std::to_wstring(res.status) + L" body=" + ToW(body));
+        return out;
+    }
+
+    try {
+        json j = json::parse(res.body);
+        if (j.contains("items") && j["items"].is_array()) {
+            for (const auto& row : j["items"]) {
+                supporter::RecentSupporter item;
+                item.platform = "youtube";
+                item.support_type = "member";
+                item.id = row.value("etag", std::string{});
+
+                const auto& snippet = row.contains("snippet") && row["snippet"].is_object()
+                    ? row["snippet"] : json::object();
+
+                if (snippet.contains("membershipsDetails") && snippet["membershipsDetails"].is_object()) {
+                    const auto& memberships = snippet["membershipsDetails"];
+
+                    if (memberships.contains("membershipsDuration") && memberships["membershipsDuration"].is_object()) {
+                        const auto& duration = memberships["membershipsDuration"];
+                        item.supported_at_ms = ParseIsoToEpochMs(duration.value("memberSince", std::string{}));
+                    }
+
+                    item.tier_name = memberships.value("highestAccessibleLevelDisplayName", std::string{});
+                }
+
+                if (snippet.contains("memberDetails") && snippet["memberDetails"].is_object()) {
+                    const auto& member = snippet["memberDetails"];
+                    item.display_name = member.value("displayName", std::string{});
+                    if (item.id.empty()) item.id = member.value("channelId", std::string{});
+                }
+
+                if (item.display_name.empty()) continue;
+                out.items.push_back(std::move(item));
+            }
+        }
+    } catch (...) {
+        out.status.error = "youtube members.list response parse failed";
+        SafeLog(log_, L"[Supporters][YouTube] Failed to parse members.list response");
+        return out;
+    }
+
+    out.status.ok = out.status.error.empty();
+    out.status.item_count = static_cast<int>(out.items.size());
+    return out;
+}
+
+} // namespace youtube

--- a/Mode-S Client/integrations/youtube/YouTubeSupporterProvider.h
+++ b/Mode-S Client/integrations/youtube/YouTubeSupporterProvider.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+
+#include "supporter/RecentSupporter.h"
+
+namespace youtube {
+
+class YouTubeSupporterProvider {
+public:
+    using AccessTokenFn = std::function<std::optional<std::string>()>;
+    using StringFn = std::function<std::optional<std::string>()>;
+    using LogFn = std::function<void(const std::wstring&)>;
+
+    YouTubeSupporterProvider(AccessTokenFn access_token,
+                             StringFn channel_id,
+                             LogFn log);
+
+    supporter::FetchResult FetchRecent(int limit) const;
+
+private:
+    AccessTokenFn access_token_;
+    StringFn channel_id_;
+    LogFn log_;
+};
+
+} // namespace youtube

--- a/Mode-S Client/src/app/AppBootstrap.cpp
+++ b/Mode-S Client/src/app/AppBootstrap.cpp
@@ -461,8 +461,22 @@ void StartBackend(
             return ok;
         };
 
+    opt.twitch_get_access_token = [&twitchAuth]() -> std::optional<std::string> {
+        return twitchAuth.GetAccessToken();
+        };
+
+    opt.twitch_get_client_id = []() -> std::optional<std::string> {
+        const std::string client_id = EmbeddedOAuthConfig::TwitchClientId();
+        if (client_id.empty()) return std::nullopt;
+        return client_id;
+        };
+
     opt.youtube_get_access_token = [&youtubeAuth]() -> std::optional<std::string> {
         return youtubeAuth.GetAccessToken();
+        };
+
+    opt.youtube_get_channel_id = [&youtubeAuth]() -> std::optional<std::string> {
+        return youtubeAuth.GetChannelId();
         };
 
     opt.youtube_auth_info_json = [&youtubeAuth]() {

--- a/Mode-S Client/src/http/HttpServer.cpp
+++ b/Mode-S Client/src/http/HttpServer.cpp
@@ -20,6 +20,7 @@
 #include "../../integrations/simconnect/SimConnectWorker.h"
 #include "../AppConfig.h"
 #include "../oauth/EmbeddedOAuthConfig.h"
+#include "../supporter/SupporterFeedService.h"
 
 namespace {
 
@@ -775,6 +776,27 @@ void HttpServer::RegisterRoutes() {
     svr.Get("/api/platform/status", [&](const httplib::Request&, httplib::Response& res) {
         auto j = state_.platform_runtime_state_json();
         res.set_content(j.dump(2), "application/json; charset=utf-8");
+        });
+
+    svr.Get("/api/supporters/recent", [&](const httplib::Request& req, httplib::Response& res) {
+        int limit = 16;
+        if (req.has_param("limit")) {
+            try { limit = std::stoi(req.get_param_value("limit")); }
+            catch (...) { limit = 16; }
+        }
+
+        supporter::SupporterFeedService feed(
+            state_,
+            config_.twitch_login,
+            opt_.twitch_get_access_token,
+            opt_.twitch_get_client_id,
+            opt_.youtube_get_access_token,
+            opt_.youtube_get_channel_id,
+            log_);
+
+        const auto payload = supporter::ToJson(feed.FetchRecent(limit));
+        res.status = 200;
+        res.set_content(payload.dump(2), "application/json; charset=utf-8");
         });
 
     // --- API: SimBrief flight plan summary (for MSFS overlays) ---

--- a/Mode-S Client/src/http/HttpServer.h
+++ b/Mode-S Client/src/http/HttpServer.h
@@ -53,8 +53,11 @@ public:
                            const std::string& redirect_uri,
                            std::string* out_error)> youtube_auth_handle_callback;
 
-        // YouTube API access token (non-interactive). Used by /api/youtube/vod/* endpoints.
+        // Platform API accessors used by local HTTP endpoints.
+        std::function<std::optional<std::string>()> twitch_get_access_token;
+        std::function<std::optional<std::string>()> twitch_get_client_id;
         std::function<std::optional<std::string>()> youtube_get_access_token;
+        std::function<std::optional<std::string>()> youtube_get_channel_id;
     };
 
     using LogFn = std::function<void(const std::wstring&)>;

--- a/Mode-S Client/src/supporter/RecentSupporter.cpp
+++ b/Mode-S Client/src/supporter/RecentSupporter.cpp
@@ -1,0 +1,43 @@
+#include "supporter/RecentSupporter.h"
+
+namespace supporter {
+
+nlohmann::json ToJson(const RecentSupporter& item) {
+    nlohmann::json j;
+    j["platform"] = item.platform;
+    j["id"] = item.id;
+    j["display_name"] = item.display_name;
+    j["supported_at"] = item.supported_at_ms;
+    j["support_type"] = item.support_type;
+    j["tier_name"] = item.tier_name;
+    j["is_gift"] = item.is_gift;
+    j["is_renewal"] = item.is_renewal;
+    return j;
+}
+
+nlohmann::json ToJson(const SourceStatus& status) {
+    nlohmann::json j;
+    j["ok"] = status.ok;
+    j["connected"] = status.connected;
+    j["error"] = status.error;
+    j["item_count"] = status.item_count;
+    return j;
+}
+
+nlohmann::json ToJson(const FeedResult& feed) {
+    nlohmann::json items = nlohmann::json::array();
+    for (const auto& item : feed.items) {
+        items.push_back(ToJson(item));
+    }
+
+    nlohmann::json j;
+    j["items"] = std::move(items);
+    j["total"] = static_cast<int>(feed.items.size());
+    j["sources"] = {
+        {"twitch", ToJson(feed.twitch)},
+        {"youtube", ToJson(feed.youtube)}
+    };
+    return j;
+}
+
+} // namespace supporter

--- a/Mode-S Client/src/supporter/RecentSupporter.h
+++ b/Mode-S Client/src/supporter/RecentSupporter.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "json.hpp"
+
+namespace supporter {
+
+struct RecentSupporter {
+    std::string platform;       // twitch | youtube
+    std::string id;
+    std::string display_name;
+    std::int64_t supported_at_ms = 0;
+    std::string support_type;   // subscriber | member
+    std::string tier_name;
+    bool is_gift = false;
+    bool is_renewal = false;
+};
+
+struct SourceStatus {
+    bool ok = false;
+    bool connected = false;
+    std::string error;
+    int item_count = 0;
+};
+
+struct FetchResult {
+    std::vector<RecentSupporter> items;
+    SourceStatus status;
+};
+
+struct FeedResult {
+    std::vector<RecentSupporter> items;
+    SourceStatus twitch;
+    SourceStatus youtube;
+};
+
+nlohmann::json ToJson(const RecentSupporter& item);
+nlohmann::json ToJson(const SourceStatus& status);
+nlohmann::json ToJson(const FeedResult& feed);
+
+} // namespace supporter

--- a/Mode-S Client/src/supporter/SupporterFeedService.cpp
+++ b/Mode-S Client/src/supporter/SupporterFeedService.cpp
@@ -1,0 +1,59 @@
+#include "supporter/SupporterFeedService.h"
+
+#include <algorithm>
+
+#include "AppState.h"
+#include "supporter/RecentSupporter.h"
+#include "twitch/TwitchSupporterProvider.h"
+#include "youtube/YouTubeSupporterProvider.h"
+
+namespace supporter {
+
+SupporterFeedService::SupporterFeedService(AppState& state,
+                                           std::string twitch_login,
+                                           AccessTokenFn twitch_access_token,
+                                           StringFn twitch_client_id,
+                                           AccessTokenFn youtube_access_token,
+                                           StringFn youtube_channel_id,
+                                           LogFn log)
+    : state_(state)
+    , twitch_login_(std::move(twitch_login))
+    , twitch_access_token_(std::move(twitch_access_token))
+    , twitch_client_id_(std::move(twitch_client_id))
+    , youtube_access_token_(std::move(youtube_access_token))
+    , youtube_channel_id_(std::move(youtube_channel_id))
+    , log_(std::move(log)) {
+}
+
+FeedResult SupporterFeedService::FetchRecent(int limit) const {
+    if (limit <= 0) limit = 16;
+    if (limit > 50) limit = 50;
+
+    twitch::TwitchSupporterProvider twitch_provider(state_, twitch_login_, twitch_access_token_, twitch_client_id_, log_);
+    youtube::YouTubeSupporterProvider youtube_provider(youtube_access_token_, youtube_channel_id_, log_);
+
+    FetchResult twitch = twitch_provider.FetchRecent(limit);
+    FetchResult youtube = youtube_provider.FetchRecent(limit);
+
+    FeedResult out;
+    out.twitch = twitch.status;
+    out.youtube = youtube.status;
+
+    out.items.reserve(twitch.items.size() + youtube.items.size());
+    out.items.insert(out.items.end(), twitch.items.begin(), twitch.items.end());
+    out.items.insert(out.items.end(), youtube.items.begin(), youtube.items.end());
+
+    std::sort(out.items.begin(), out.items.end(), [](const RecentSupporter& a, const RecentSupporter& b) {
+        if (a.supported_at_ms != b.supported_at_ms) return a.supported_at_ms > b.supported_at_ms;
+        if (a.platform != b.platform) return a.platform < b.platform;
+        return a.display_name < b.display_name;
+    });
+
+    if (static_cast<int>(out.items.size()) > limit) {
+        out.items.resize(static_cast<size_t>(limit));
+    }
+
+    return out;
+}
+
+} // namespace supporter

--- a/Mode-S Client/src/supporter/SupporterFeedService.h
+++ b/Mode-S Client/src/supporter/SupporterFeedService.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+
+#include "supporter/RecentSupporter.h"
+
+class AppState;
+
+namespace supporter {
+
+class SupporterFeedService {
+public:
+    using AccessTokenFn = std::function<std::optional<std::string>()>;
+    using StringFn = std::function<std::optional<std::string>()>;
+    using LogFn = std::function<void(const std::wstring&)>;
+
+    SupporterFeedService(AppState& state,
+                         std::string twitch_login,
+                         AccessTokenFn twitch_access_token,
+                         StringFn twitch_client_id,
+                         AccessTokenFn youtube_access_token,
+                         StringFn youtube_channel_id,
+                         LogFn log);
+
+    FeedResult FetchRecent(int limit) const;
+
+private:
+    AppState& state_;
+    std::string twitch_login_;
+    AccessTokenFn twitch_access_token_;
+    StringFn twitch_client_id_;
+    AccessTokenFn youtube_access_token_;
+    StringFn youtube_channel_id_;
+    LogFn log_;
+};
+
+} // namespace supporter


### PR DESCRIPTION
Adds a backend supporters feed endpoint and uses it to power Twitch current subscriber panels in the post-stream overlays.

This work introduces the supporter data plumbing needed for overlays to consume a unified supporter feed, then updates the landscape and portrait end screens to show a scrolling Twitch current-subscriber roster.

#130 

## Backend changes

- added a shared supporter model
- added supporter provider logic for platform feeds
- added merged supporter feed service
- added `/api/supporters/recent`
- added source status/error reporting so overlays can degrade cleanly when a platform is unavailable

## Overlay changes

- added a Twitch current subscribers panel to the landscape post-stream overlay
- added a Twitch current subscribers panel to the portrait post-stream overlay
- wired both overlays to the local supporters API
- filtered overlay rendering to Twitch subscriber entries
- used "Current Subscribers" wording rather than implying recent chronological ordering
- added continuous looping scroll behaviour
- smoothed the scrolling behaviour
- tuned portrait and landscape panel sizing/alignment
- removed incorrect empty-state text from the portrait version

## Notes

- Twitch is currently the usable source for this feature
- YouTube support was partially implemented in the backend, but `members.list` is still blocked by a 403 issue and is not relied on by the overlays
- the overlay therefore currently behaves as a Twitch-powered current-subscriber roster

## Testing

Tested by:
- calling `/api/supporters/recent`
- confirming Twitch supporter data is returned
- confirming source status is included
- loading the landscape post-stream overlay locally
- loading the portrait post-stream overlay locally
- confirming subscriber rows render and loop correctly
- confirming the panels remain within layout bounds

## Follow-up

- resolve the outstanding YouTube `members.list` 403 issue
- improve Twitch recency using cached EventSub subscription activity
- optionally add a true recent-supporters mode later