### PR TITLE
Fix YouTube subscriber alerts and startup stability

### DIFF
--- a/Mode-S Client/Mode-S Client.vcxproj
+++ b/Mode-S Client/Mode-S Client.vcxproj
@@ -200,6 +200,7 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
     <ClInclude Include="integrations\youtube\YouTubeAuth.h" />
     <ClInclude Include="integrations\youtube\YouTubeLiveChatService.h" />
     <ClInclude Include="integrations\youtube\YouTubeSidecar.h" />
+    <ClInclude Include="integrations\youtube\YouTubeSubscriberProvider.h" />
     <ClInclude Include="integrations\youtube\YouTubeSupporterProvider.h" />
     <ClInclude Include="src\AppConfig.h" />
     <ClInclude Include="src\AppState.h" />
@@ -241,6 +242,7 @@ xcopy /E /I /Y "$(ProjectDir)assets\*" "$(TargetDir)assets\"</Command>
     <ClCompile Include="integrations\youtube\YouTubeAuth.cpp" />
     <ClCompile Include="integrations\youtube\YouTubeLiveChatService.cpp" />
     <ClCompile Include="integrations\youtube\YouTubeSidecar.cpp" />
+    <ClCompile Include="integrations\youtube\YouTubeSubscriberProvider.cpp" />
     <ClCompile Include="integrations\youtube\YouTubeSupporterProvider.cpp" />
     <ClCompile Include="src\AppState.cpp" />
     <ClCompile Include="src\app\AppBootstrap.cpp" />

--- a/Mode-S Client/integrations/youtube/YouTubeSubscriberProvider.cpp
+++ b/Mode-S Client/integrations/youtube/YouTubeSubscriberProvider.cpp
@@ -1,0 +1,279 @@
+#include "youtube/YouTubeSubscriberProvider.h"
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <winhttp.h>
+#pragma comment(lib, "winhttp.lib")
+
+#include <ctime>
+#include <utility>
+
+#include "json.hpp"
+
+using json = nlohmann::json;
+
+namespace {
+
+std::wstring ToW(const std::string& s) {
+    if (s.empty()) return L"";
+    int len = MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()), nullptr, 0);
+    if (len <= 0) return L"";
+    std::wstring w(static_cast<size_t>(len), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()), w.data(), len);
+    return w;
+}
+
+void SafeLog(const std::function<void(const std::wstring&)>& log, const std::wstring& msg) {
+    if (!log) return;
+    try { log(msg); } catch (...) {}
+}
+
+struct HttpResult {
+    int status = 0;
+    DWORD winerr = 0;
+    std::string body;
+};
+
+struct WinHttpHandle {
+    HINTERNET h = nullptr;
+    WinHttpHandle() = default;
+    explicit WinHttpHandle(HINTERNET v) : h(v) {}
+    ~WinHttpHandle() { if (h) WinHttpCloseHandle(h); }
+    WinHttpHandle(const WinHttpHandle&) = delete;
+    WinHttpHandle& operator=(const WinHttpHandle&) = delete;
+    operator HINTERNET() const { return h; }
+    bool valid() const { return h != nullptr; }
+};
+
+HttpResult WinHttpGet(const std::wstring& host,
+                      INTERNET_PORT port,
+                      const std::wstring& path,
+                      const std::wstring& extra_headers,
+                      bool secure) {
+    HttpResult r;
+    WinHttpHandle session(WinHttpOpen(L"ModeSClient/1.0", WINHTTP_ACCESS_TYPE_NO_PROXY,
+                                      WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0));
+    if (!session.valid()) { r.winerr = GetLastError(); return r; }
+
+    WinHttpSetTimeouts(session, 5000, 5000, 8000, 8000);
+    WinHttpHandle connect(WinHttpConnect(session, host.c_str(), port, 0));
+    if (!connect.valid()) { r.winerr = GetLastError(); return r; }
+
+    DWORD flags = secure ? WINHTTP_FLAG_SECURE : 0;
+    WinHttpHandle request(WinHttpOpenRequest(connect, L"GET", path.c_str(), nullptr,
+                                             WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, flags));
+    if (!request.valid()) { r.winerr = GetLastError(); return r; }
+
+    const std::wstring base_headers =
+        L"Accept: application/json\r\n"
+        L"Accept-Encoding: identity\r\n"
+        L"Connection: close\r\n";
+    WinHttpAddRequestHeaders(request, base_headers.c_str(), static_cast<ULONG>(-1), WINHTTP_ADDREQ_FLAG_ADD);
+    if (!extra_headers.empty()) {
+        WinHttpAddRequestHeaders(request, extra_headers.c_str(), static_cast<ULONG>(-1), WINHTTP_ADDREQ_FLAG_ADD);
+    }
+
+    BOOL ok = WinHttpSendRequest(request, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+                                 WINHTTP_NO_REQUEST_DATA, 0, 0, 0);
+    if (!ok) { r.winerr = GetLastError(); return r; }
+
+    ok = WinHttpReceiveResponse(request, nullptr);
+    if (!ok) { r.winerr = GetLastError(); return r; }
+
+    DWORD status = 0;
+    DWORD status_size = sizeof(status);
+    if (WinHttpQueryHeaders(request, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                            WINHTTP_HEADER_NAME_BY_INDEX, &status, &status_size, WINHTTP_NO_HEADER_INDEX)) {
+        r.status = static_cast<int>(status);
+    }
+
+    std::string out;
+    for (;;) {
+        DWORD avail = 0;
+        if (!WinHttpQueryDataAvailable(request, &avail)) { r.winerr = GetLastError(); break; }
+        if (avail == 0) break;
+
+        const size_t cur = out.size();
+        out.resize(cur + static_cast<size_t>(avail));
+
+        DWORD read = 0;
+        if (!WinHttpReadData(request, out.data() + cur, avail, &read)) { r.winerr = GetLastError(); break; }
+        out.resize(cur + static_cast<size_t>(read));
+    }
+
+    r.body = std::move(out);
+    return r;
+}
+
+std::int64_t ParseIsoToEpochMs(const std::string& iso) {
+    if (iso.size() < 19) return 0;
+
+    std::tm tm{};
+    try {
+        tm.tm_year = std::stoi(iso.substr(0, 4)) - 1900;
+        tm.tm_mon = std::stoi(iso.substr(5, 2)) - 1;
+        tm.tm_mday = std::stoi(iso.substr(8, 2));
+        tm.tm_hour = std::stoi(iso.substr(11, 2));
+        tm.tm_min = std::stoi(iso.substr(14, 2));
+        tm.tm_sec = std::stoi(iso.substr(17, 2));
+    }
+    catch (...) {
+        return 0;
+    }
+
+#ifdef _WIN32
+    const __time64_t sec = _mkgmtime64(&tm);
+    if (sec < 0) return 0;
+    return static_cast<std::int64_t>(sec) * 1000;
+#else
+    const std::time_t sec = timegm(&tm);
+    if (sec < 0) return 0;
+    return static_cast<std::int64_t>(sec) * 1000;
+#endif
+}
+
+std::string JsonString(const json& j, const char* key) {
+    auto it = j.find(key);
+    if (it == j.end() || !it->is_string()) return {};
+    return it->get<std::string>();
+}
+
+std::string ThumbnailUrl(const json& node) {
+    try {
+        if (!node.is_object()) return {};
+        auto it = node.find("thumbnails");
+        if (it == node.end() || !it->is_object()) return {};
+        const auto& thumbs = *it;
+
+        static const char* kPreferred[] = { "high", "medium", "default" };
+        for (const char* key : kPreferred) {
+            auto t = thumbs.find(key);
+            if (t != thumbs.end() && t->is_object()) {
+                const std::string url = JsonString(*t, "url");
+                if (!url.empty()) return url;
+            }
+        }
+
+        for (auto jt = thumbs.begin(); jt != thumbs.end(); ++jt) {
+            if (!jt.value().is_object()) continue;
+            const std::string url = JsonString(jt.value(), "url");
+            if (!url.empty()) return url;
+        }
+    }
+    catch (...) {}
+
+    return {};
+}
+
+} // namespace
+
+namespace youtube {
+
+YouTubeSubscriberProvider::YouTubeSubscriberProvider(AccessTokenFn access_token, LogFn log)
+    : access_token_(std::move(access_token))
+    , log_(std::move(log)) {
+}
+
+std::vector<RecentSubscriber> YouTubeSubscriberProvider::FetchRecent(int limit,
+                                                                     std::string* out_error) const {
+    if (out_error) out_error->clear();
+
+    std::vector<RecentSubscriber> out;
+    if (limit <= 0) limit = 16;
+    if (limit > 50) limit = 50;
+
+    const auto token = access_token_ ? access_token_() : std::nullopt;
+    if (!token.has_value() || token->empty()) {
+        if (out_error) *out_error = "youtube access token unavailable";
+        return out;
+    }
+
+    std::wstring headers;
+    headers += L"Authorization: Bearer " + ToW(*token) + L"\r\n";
+
+    const std::string path =
+        "/youtube/v3/subscriptions?part=snippet%2CsubscriberSnippet&myRecentSubscribers=true&maxResults=" +
+        std::to_string(limit);
+
+    HttpResult res = WinHttpGet(L"www.googleapis.com",
+                                INTERNET_DEFAULT_HTTPS_PORT,
+                                ToW(path),
+                                headers,
+                                true);
+
+    if (res.status < 200 || res.status >= 300) {
+        std::string body = res.body;
+        if (body.size() > 600) body.resize(600);
+
+        const std::string msg = "youtube subscriptions.list request failed: HTTP " +
+            std::to_string(res.status) + ": " + body;
+
+        SafeLog(log_, L"[Subscribers][YouTube] subscriptions.list failed with HTTP " +
+            std::to_wstring(res.status) + L" body=" + ToW(body));
+
+        if (out_error) *out_error = msg;
+        return out;
+    }
+
+    try {
+        const json j = json::parse(res.body);
+        auto items = j.find("items");
+        if (items == j.end() || !items->is_array()) {
+            return out;
+        }
+
+        out.reserve(items->size());
+
+        for (const auto& row : *items) {
+            RecentSubscriber item;
+            item.subscription_id = row.value("id", std::string{});
+
+            if (row.contains("subscriberSnippet") && row["subscriberSnippet"].is_object()) {
+                const auto& snippet = row["subscriberSnippet"];
+                item.subscriber_channel_id = JsonString(snippet, "channelId");
+                item.subscriber_title = JsonString(snippet, "title");
+                item.subscriber_avatar_url = ThumbnailUrl(snippet);
+            }
+
+            if (row.contains("snippet") && row["snippet"].is_object()) {
+                const auto& snippet = row["snippet"];
+                const std::string published = JsonString(snippet, "publishedAt");
+                if (!published.empty()) {
+                    item.subscribed_at_ms = ParseIsoToEpochMs(published);
+                }
+            }
+
+            if (item.subscription_id.empty()) {
+                if (!item.subscriber_channel_id.empty()) {
+                    item.subscription_id = item.subscriber_channel_id;
+                    if (item.subscribed_at_ms > 0) {
+                        item.subscription_id += ":" + std::to_string(item.subscribed_at_ms);
+                    }
+                }
+                else if (!item.subscriber_title.empty()) {
+                    item.subscription_id = item.subscriber_title;
+                    if (item.subscribed_at_ms > 0) {
+                        item.subscription_id += ":" + std::to_string(item.subscribed_at_ms);
+                    }
+                }
+            }
+
+            if (item.subscription_id.empty()) {
+                continue;
+            }
+
+            out.push_back(std::move(item));
+        }
+    }
+    catch (const std::exception& ex) {
+        const std::string msg = std::string("youtube subscriptions JSON parse failed: ") + ex.what();
+        SafeLog(log_, L"[Subscribers][YouTube] " + ToW(msg));
+        if (out_error) *out_error = msg;
+        out.clear();
+    }
+
+    return out;
+}
+
+} // namespace youtube

--- a/Mode-S Client/integrations/youtube/YouTubeSubscriberProvider.h
+++ b/Mode-S Client/integrations/youtube/YouTubeSubscriberProvider.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace youtube {
+
+struct RecentSubscriber {
+    std::string subscription_id;
+    std::string subscriber_channel_id;
+    std::string subscriber_title;
+    std::string subscriber_avatar_url;
+    std::int64_t subscribed_at_ms = 0;
+};
+
+class YouTubeSubscriberProvider {
+public:
+    using AccessTokenFn = std::function<std::optional<std::string>()>;
+    using LogFn = std::function<void(const std::wstring&)>;
+
+    YouTubeSubscriberProvider(AccessTokenFn access_token, LogFn log);
+
+    std::vector<RecentSubscriber> FetchRecent(int limit,
+                                              std::string* out_error = nullptr) const;
+
+private:
+    AccessTokenFn access_token_;
+    LogFn log_;
+};
+
+} // namespace youtube

--- a/Mode-S Client/scripts/sidecar/youtube_sidecar.py
+++ b/Mode-S Client/scripts/sidecar/youtube_sidecar.py
@@ -4,7 +4,9 @@
 # - Config loading IDENTICAL to tiktok_sidecar.py
 # - Emits:
 #     * youtube.stats  {live, viewers, followers}
-#     * youtube.chat   {user, message, ts_ms, id}
+#
+# Subscriber alerts are now handled by the native C++ YouTube subscriber poller.
+# This sidecar only provides public-page stats and live chat scraping support.
 #
 # Notes:
 # - We avoid Brotli by requesting identity/gzip only (WinHTTP & urllib don't reliably handle br)
@@ -513,11 +515,6 @@ def main():
     chat_state = {"video_id": "", "api_key": "", "client_ver": "", "visitor": "", "continuation": ""}
     seen_ids = set()
 
-    # follower delta state (synthetic "subscribe" approximation)
-    last_followers = None
-    last_delta_emit_ts = 0.0
-    DELTA_DEBOUNCE_SEC = 30.0  # avoid spam if YouTube updates in bursts
-
     while True:
         cfg = load_config()
         handle = sanitize_handle(cfg.get("youtube_handle", ""))
@@ -549,33 +546,6 @@ def main():
         followers = parse_followers(channel_html)
         if followers == 0:
             followers = parse_followers(live_html)
-
-        # --- Synthetic 'subscription' event via follower-count delta ---
-        # YouTube does not provide real-time named subscription events.
-        # We approximate by watching subscriber count changes and emitting an
-        # anonymous delta event.
-        now = time.time()
-        if followers > 0:
-            if last_followers is None:
-                last_followers = followers
-            else:
-                if followers > last_followers:
-                    delta = followers - last_followers
-
-                    # Debounce + sanity bounds
-                    if delta > 0 and (now - last_delta_emit_ts) >= DELTA_DEBOUNCE_SEC:
-                        emit({
-                            "type": "youtube.followers_delta",
-                            "ts": now,
-                            "prev": last_followers,
-                            "followers": followers,
-                            "delta": delta,
-                        })
-                        last_delta_emit_ts = now
-
-                # Always update baseline when we have a valid count
-                last_followers = followers
-        # --- /Synthetic delta ---
 
         emit({
             "type": "youtube.stats",

--- a/Mode-S Client/src/app/AppBootstrap.cpp
+++ b/Mode-S Client/src/app/AppBootstrap.cpp
@@ -324,7 +324,12 @@ void StartBackend(
         }
 
         if (twitchHelixBoundLogin != config.twitch_login) {
-            restartTwitchHelixPoller("web dashboard start");
+            if (restartTwitchHelixPoller) {
+                restartTwitchHelixPoller("web dashboard start");
+            }
+            else {
+                LogLine(L"TWITCH: Helix poller restart callback is not wired.");
+            }
         }
 
         const bool ok = PlatformControl::StartOrRestartTwitchIrc(

--- a/Mode-S Client/src/platform/PlatformControl.cpp
+++ b/Mode-S Client/src/platform/PlatformControl.cpp
@@ -4,13 +4,22 @@
 #include <windows.h>
 #include <string>
 #include <algorithm>
+#include <atomic>
 #include <chrono>
+#include <cstdio>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <unordered_set>
+#include <vector>
 
 #include "tiktok/TikTokSidecar.h"
 #include "twitch/TwitchIrcWsClient.h"
 #include "twitch/TwitchEventSubWsClient.h"
 #include "chat/ChatAggregator.h"
+#include "AppConfig.h"
 #include "AppState.h"
+#include "youtube/YouTubeSubscriberProvider.h"
 
 using nlohmann::json;
 
@@ -62,6 +71,174 @@ static std::wstring ToW(const std::string& s) {
     std::wstring w(len, L'\0');
     MultiByteToWideChar(CP_UTF8, 0, s.c_str(), (int)s.size(), w.data(), len);
     return w;
+}
+
+
+struct YouTubeSubscriberPollerState {
+    std::atomic<bool> running{ false };
+    std::thread thread;
+    std::mutex mu;
+    std::unordered_set<std::string> seen_ids;
+    bool seeded = false;
+};
+
+static YouTubeSubscriberPollerState g_youtubeSubscriberPoller;
+
+static std::optional<std::string> LoadYouTubeAccessTokenFromConfig() {
+    const std::wstring path = AppConfig::ConfigPath();
+
+    FILE* f = nullptr;
+    _wfopen_s(&f, path.c_str(), L"rb");
+    if (!f) return std::nullopt;
+
+    fseek(f, 0, SEEK_END);
+    long sz = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    std::string data;
+    data.resize(sz > 0 ? (size_t)sz : 0);
+    if (sz > 0) fread(data.data(), 1, (size_t)sz, f);
+    fclose(f);
+
+    try {
+        const auto j = nlohmann::json::parse(data, nullptr, false);
+        if (!j.is_object()) return std::nullopt;
+
+        const auto yt = j.value("youtube", nlohmann::json::object());
+        if (!yt.is_object()) return std::nullopt;
+
+        const std::string token = yt.value("access_token", std::string{});
+        if (token.empty()) return std::nullopt;
+        return token;
+    }
+    catch (...) {
+        return std::nullopt;
+    }
+}
+
+static std::int64_t NowMs() {
+    return (std::int64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+}
+
+static void StopYouTubeSubscriberPoller();
+
+static void StartYouTubeSubscriberPoller(AppState& state, PlatformControl::LogFn log) {
+    StopYouTubeSubscriberPoller();
+
+    {
+        std::lock_guard<std::mutex> lock(g_youtubeSubscriberPoller.mu);
+        g_youtubeSubscriberPoller.seen_ids.clear();
+        g_youtubeSubscriberPoller.seeded = false;
+    }
+
+    g_youtubeSubscriberPoller.running.store(true);
+
+    g_youtubeSubscriberPoller.thread = std::thread([&state, log]() {
+        youtube::YouTubeSubscriberProvider provider(
+            []() { return LoadYouTubeAccessTokenFromConfig(); },
+            [log](const std::wstring& msg) {
+                if (log) log(msg);
+            });
+
+        std::string last_status;
+
+        while (g_youtubeSubscriberPoller.running.load()) {
+            std::string error;
+            auto recent = provider.FetchRecent(25, &error);
+
+            const bool fetch_ok = error.empty();
+            if (!fetch_ok) {
+                if (error != last_status) {
+                    last_status = error;
+                    if (log && !error.empty()) {
+                        log(L"YOUTUBE: subscriber poller warning: " + ToW(error));
+                    }
+                }
+            }
+            else {
+                if (!last_status.empty() && log) {
+                    log(L"YOUTUBE: subscriber poller recovered.");
+                }
+                last_status.clear();
+
+                std::vector<youtube::RecentSubscriber> unseen_to_emit;
+                bool seeded_now = false;
+
+                {
+                    std::lock_guard<std::mutex> lock(g_youtubeSubscriberPoller.mu);
+
+                    if (!g_youtubeSubscriberPoller.seeded) {
+                        for (const auto& item : recent) {
+                            if (!item.subscription_id.empty()) {
+                                g_youtubeSubscriberPoller.seen_ids.insert(item.subscription_id);
+                            }
+                        }
+                        g_youtubeSubscriberPoller.seeded = true;
+                        seeded_now = true;
+                    }
+                    else {
+                        for (const auto& item : recent) {
+                            if (item.subscription_id.empty()) continue;
+                            const auto inserted = g_youtubeSubscriberPoller.seen_ids.insert(item.subscription_id);
+                            if (inserted.second) {
+                                unseen_to_emit.push_back(item);
+                            }
+                        }
+                    }
+
+                    if (g_youtubeSubscriberPoller.seen_ids.size() > 4000) {
+                        g_youtubeSubscriberPoller.seen_ids.clear();
+                        for (const auto& item : recent) {
+                            if (!item.subscription_id.empty()) {
+                                g_youtubeSubscriberPoller.seen_ids.insert(item.subscription_id);
+                            }
+                        }
+                    }
+                }
+
+                if (seeded_now && log) {
+                    log(L"YOUTUBE: subscriber poller seeded from recent subscriber list.");
+                }
+
+                for (auto it = unseen_to_emit.rbegin(); it != unseen_to_emit.rend(); ++it) {
+                    if (!g_youtubeSubscriberPoller.running.load()) break;
+
+                    EventItem e;
+                    e.platform = "youtube";
+                    e.type = "subscribe";
+                    e.user = it->subscriber_title.empty() ? "Someone" : it->subscriber_title;
+                    e.message = "subscribed";
+                    e.ts_ms = it->subscribed_at_ms > 0 ? it->subscribed_at_ms : NowMs();
+                    state.push_youtube_event(e);
+
+                    if (log) {
+                        log(L"YOUTUBE: new public subscriber: " + ToW(e.user));
+                    }
+                }
+            }
+
+            for (int i = 0; i < 15 && g_youtubeSubscriberPoller.running.load(); ++i) {
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+            }
+        }
+    });
+}
+
+static void StopYouTubeSubscriberPoller() {
+    g_youtubeSubscriberPoller.running.store(false);
+
+    if (g_youtubeSubscriberPoller.thread.joinable()) {
+        try {
+            g_youtubeSubscriberPoller.thread.join();
+        }
+        catch (...) {
+        }
+    }
+
+    std::lock_guard<std::mutex> lock(g_youtubeSubscriberPoller.mu);
+    g_youtubeSubscriberPoller.seen_ids.clear();
+    g_youtubeSubscriberPoller.seeded = false;
 }
 
 } // namespace
@@ -196,36 +373,6 @@ namespace PlatformControl {
                 c.ts_ms = (std::int64_t)(ts * 1000.0);
                 chat.Add(std::move(c));
             }
-            else if (type == "youtube.followers_delta") {
-                const int delta = j.value("delta", 0);
-                const int followers = j.value("followers", 0);
-
-                if (followers > 0) {
-                    state.set_youtube_followers(followers);
-                }
-
-                std::int64_t ts_ms = 0;
-                if (j.contains("ts")) {
-                    const double ts = j.value("ts", 0.0);
-                    ts_ms = (std::int64_t)(ts * 1000.0);
-                }
-                if (ts_ms <= 0) {
-                    ts_ms = (std::int64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
-                        std::chrono::system_clock::now().time_since_epoch()
-                    ).count();
-                }
-
-                const int n = (std::max)(0, (std::min)(delta, 25));
-                for (int i = 0; i < n; ++i) {
-                    EventItem e;
-                    e.platform = "youtube";
-                    e.type = "subscribe";
-                    e.user = "Someone";
-                    e.message = "followed 👋";
-                    e.ts_ms = ts_ms + i;
-                    state.push_youtube_event(e);
-                }
-            }
             else if (type == "youtube.stats") {
                 bool live = j.value("live", false);
                 int viewers = j.value("viewers", 0);
@@ -237,6 +384,13 @@ namespace PlatformControl {
                 state.set_youtube_viewers(j.value("viewers", 0));
             }
             });
+
+        if (ok) {
+            StartYouTubeSubscriberPoller(state, log);
+        }
+        else {
+            StopYouTubeSubscriberPoller();
+        }
 
         if (log) {
             log(ok ? L"YouTube sidecar started/restarted." :
@@ -288,6 +442,7 @@ void StopTikTok(TikTokSidecar& tiktok, AppState& state, LogFn log) {
 }
 void StopYouTube(TikTokSidecar& youtube, AppState& state, LogFn log) {
     youtube.stop();
+    StopYouTubeSubscriberPoller();
     state.set_youtube_live(false);
     state.set_youtube_viewers(0);
     if (log) log(L"YOUTUBE: stopped.");


### PR DESCRIPTION
This PR improves YouTube subscriber alert handling and fixes a startup crash triggered from the combined platform start path.

## Changes

- added native YouTube recent-subscriber polling using the YouTube API
- removed the old synthetic YouTube subscriber approximation from the Python sidecar
- pushed real YouTube subscribe events into the existing alert/event pipeline
- kept YouTube alerts styled consistently with the existing Twitch/TikTok overlay flow while preserving YouTube red platform tinting
- adjusted YouTube subscribe event messaging so the overlay keeps the ATC-style wording instead of showing the raw payload text
- added a safety guard around the Twitch Helix restart callback to prevent a crash when using Start All Platforms
- retained existing YouTube OAuth/auth status behavior while continuing to use the configured public handle for sidecar/live-page startup

## Result

- YouTube subscribe alerts now show the subscriber name when YouTube exposes it
- YouTube alerts now render correctly in the overlay
- Start All Platforms no longer crashes when the Helix restart callback is not wired