### PR TITLE
Add !metar command with cached AviationWeather lookup

### DIFF
--- a/Mode-S Client/src/app/AppBootstrap.cpp
+++ b/Mode-S Client/src/app/AppBootstrap.cpp
@@ -331,6 +331,171 @@ static bool TrySendYouTubeReply(YouTubeAuth& youtubeAuth,
     return false;
 }
 
+
+
+static std::string TrimAscii(std::string s)
+{
+    auto is_space = [](unsigned char c) {
+        return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+    };
+    size_t a = 0;
+    size_t b = s.size();
+    while (a < b && is_space(static_cast<unsigned char>(s[a]))) ++a;
+    while (b > a && is_space(static_cast<unsigned char>(s[b - 1]))) --b;
+    return s.substr(a, b - a);
+}
+
+static std::string ToUpperAscii(std::string s)
+{
+    std::transform(s.begin(), s.end(), s.begin(),
+        [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return s;
+}
+
+static bool IsStrictIcao(const std::string& s)
+{
+    if (s.size() != 4) return false;
+    for (unsigned char c : s) {
+        if (!std::isalpha(c)) return false;
+    }
+    return true;
+}
+
+struct MetarCacheEntry {
+    long long cached_at_ms = 0;
+    std::string raw;
+};
+
+static bool TryFetchMetarFromAviationWeather(const std::string& icaoUpper,
+    std::string& outRawMetar,
+    std::string* outError)
+{
+    outRawMetar.clear();
+    if (!IsStrictIcao(icaoUpper)) {
+        if (outError) *outError = "Invalid ICAO";
+        return false;
+    }
+
+    const std::wstring headers =
+        L"Accept: text/plain\r\n"
+        L"User-Agent: Mode-S Client/1.0\r\n";
+
+    const std::wstring path =
+        L"/api/data/metar?ids=" + ToW(icaoUpper) + L"&format=raw";
+
+    const HttpResult r = WinHttpRequestUtf8(
+        L"GET",
+        L"aviationweather.gov",
+        INTERNET_DEFAULT_HTTPS_PORT,
+        path,
+        headers,
+        "",
+        true);
+
+    if (r.status == 204) {
+        if (outError) *outError = "No METAR available for " + icaoUpper;
+        return false;
+    }
+
+    if (r.status != 200) {
+        if (outError) {
+            *outError = "AviationWeather METAR lookup failed: HTTP " + std::to_string(r.status);
+            if (!r.body.empty()) *outError += " body=" + r.body;
+        }
+        return false;
+    }
+
+    std::string raw = TrimAscii(r.body);
+    if (raw.empty()) {
+        if (outError) *outError = "AviationWeather METAR lookup returned an empty response";
+        return false;
+    }
+
+    // If the upstream ever returns multiple lines, keep the first non-empty one.
+    const size_t nl = raw.find_first_of("\r\n");
+    if (nl != std::string::npos) {
+        raw = TrimAscii(raw.substr(0, nl));
+    }
+
+    if (raw.empty()) {
+        if (outError) *outError = "AviationWeather METAR lookup returned an unusable response";
+        return false;
+    }
+
+    outRawMetar = raw;
+    return true;
+}
+
+static bool TryGetMetarReply(const std::string& messageText,
+    std::string& outReply,
+    std::string* outLogError)
+{
+    outReply.clear();
+
+    auto to_lower = [](std::string s) {
+        std::transform(s.begin(), s.end(), s.begin(),
+            [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return s;
+    };
+
+    const std::string trimmed = TrimAscii(messageText);
+    if (trimmed.size() < 6 || trimmed[0] != '!') {
+        return false;
+    }
+
+    size_t firstSpace = trimmed.find_first_of(" \t\r\n");
+    std::string cmd = trimmed.substr(1, firstSpace == std::string::npos ? std::string::npos : firstSpace - 1);
+    if (to_lower(cmd) != "metar") {
+        return false;
+    }
+
+    std::string arg = (firstSpace == std::string::npos)
+        ? std::string{}
+        : TrimAscii(trimmed.substr(firstSpace + 1));
+
+    if (!IsStrictIcao(arg)) {
+        outReply = "Usage: !metar EGCC";
+        return true;
+    }
+
+    const std::string icaoUpper = ToUpperAscii(arg);
+
+    static std::mutex cacheMu;
+    static std::unordered_map<std::string, MetarCacheEntry> cache;
+
+    const long long nowMs = static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count());
+
+    {
+        std::lock_guard<std::mutex> lk(cacheMu);
+        auto it = cache.find(icaoUpper);
+        if (it != cache.end() && !it->second.raw.empty() && (nowMs - it->second.cached_at_ms) < 60000) {
+            outReply = icaoUpper + " METAR: " + it->second.raw;
+            return true;
+        }
+    }
+
+    std::string rawMetar;
+    std::string fetchError;
+    if (!TryFetchMetarFromAviationWeather(icaoUpper, rawMetar, &fetchError)) {
+        if (outLogError) *outLogError = fetchError;
+        if (fetchError.find("No METAR available") != std::string::npos) {
+            outReply = "No METAR found for " + icaoUpper;
+        }
+        else {
+            outReply = "METAR lookup unavailable right now for " + icaoUpper;
+        }
+        return true;
+    }
+
+    {
+        std::lock_guard<std::mutex> lk(cacheMu);
+        cache[icaoUpper] = MetarCacheEntry{ nowMs, rawMetar };
+    }
+
+    outReply = rawMetar;
+    return true;
+}
 std::wstring GetExeDir()
 {
     wchar_t path[MAX_PATH];
@@ -416,6 +581,50 @@ void SubscribeBotCommandHandler(AppBootstrap::Dependencies& deps)
             last_by_user[user_key] = now_ms_ll;
         }
 
+        auto send_reply = [&](std::string reply) {
+            const size_t kMaxReplyLen = bot_settings.max_reply_len;
+            if (kMaxReplyLen > 0 && reply.size() > kMaxReplyLen) {
+                reply.resize(kMaxReplyLen);
+            }
+            if (kMaxReplyLen == 0) {
+                return;
+            }
+
+            ChatMessage bot{};
+            bot.platform = m.platform;
+            bot.user = "StreamingATC.Bot";
+            bot.message = reply;
+            bot.ts_ms = static_cast<uint64_t>(now_ms_ll + 1);
+            pChat->Add(std::move(bot));
+
+            if (platform_lc == "twitch" && pTwitch) {
+                if (!pTwitch->SendPrivMsg(reply)) {
+                    LogLine(L"BOT: Twitch send failed");
+                }
+            }
+            if (platform_lc == "tiktok" && pTikTok) {
+                if (!pTikTok->send_chat(reply)) {
+                    LogLine(L"BOT: TikTok send failed (sidecar)");
+                }
+            }
+            if (platform_lc == "youtube" && pYouTubeAuth) {
+                std::string err;
+                if (!TrySendYouTubeReply(*pYouTubeAuth, reply, &err)) {
+                    LogLine(ToW(std::string("BOT: YouTube send failed: ") + err));
+                }
+            }
+        };
+
+        std::string metarReply;
+        std::string metarLogError;
+        if (TryGetMetarReply(m.message, metarReply, &metarLogError)) {
+            if (!metarLogError.empty()) {
+                LogLine(ToW(std::string("BOT: METAR lookup note: ") + metarLogError));
+            }
+            send_reply(std::move(metarReply));
+            return;
+        }
+
         std::string template_reply = pState->bot_try_get_response(
             cmd_lc,
             m.is_mod,
@@ -426,38 +635,7 @@ void SubscribeBotCommandHandler(AppBootstrap::Dependencies& deps)
         std::string reply = template_reply;
         reply = replace_all(reply, "{user}", m.user);
         reply = replace_all(reply, "{platform}", platform_lc);
-
-        const size_t kMaxReplyLen = bot_settings.max_reply_len;
-        if (kMaxReplyLen > 0 && reply.size() > kMaxReplyLen) {
-            reply.resize(kMaxReplyLen);
-        }
-        if (kMaxReplyLen == 0) {
-            return;
-        }
-
-        ChatMessage bot{};
-        bot.platform = m.platform;
-        bot.user = "StreamingATC.Bot";
-        bot.message = reply;
-        bot.ts_ms = static_cast<uint64_t>(now_ms_ll + 1);
-        pChat->Add(std::move(bot));
-
-        if (platform_lc == "twitch" && pTwitch) {
-            if (!pTwitch->SendPrivMsg(reply)) {
-                LogLine(L"BOT: Twitch send failed");
-            }
-        }
-        if (platform_lc == "tiktok" && pTikTok) {
-            if (!pTikTok->send_chat(reply)) {
-                LogLine(L"BOT: TikTok send failed (sidecar)");
-            }
-        }
-        if (platform_lc == "youtube" && pYouTubeAuth) {
-            std::string err;
-            if (!TrySendYouTubeReply(*pYouTubeAuth, reply, &err)) {
-                LogLine(ToW(std::string("BOT: YouTube send failed: ") + err));
-            }
-        }
+        send_reply(std::move(reply));
     });
 }
 


### PR DESCRIPTION
This PR adds a new `!metar <ICAO>` chat command that fetches the latest raw METAR for an airport and posts it back into chat.

The command is case-insensitive, validates the ICAO format, caches recent lookups to avoid unnecessary upstream requests, and handles lookup failures cleanly.

## What changed

- added support for `!metar <ICAO>` in the bot command handler
- validates ICAO input using a strict 4-letter format
- normalizes ICAO codes to uppercase before lookup
- fetches latest METAR data from AviationWeather
- caches METAR responses briefly per ICAO to reduce repeat calls
- returns a short usage message for missing or invalid input
- logs METAR lookup failures for diagnostics
- removed the redundant `ICAO METAR:` prefix from replies so chat output is cleaner

## Example behaviour

- `!metar EGCC` -> raw EGCC METAR in chat
- `!metar egll` -> raw EGLL METAR in chat
- `!metar` -> `Usage: !metar EGCC`
- invalid ICAO input returns a short usage/error response

Fixes #147 