### PR TITLE
Add architecture and takeover documentation

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,372 @@
+# AI Agents and AI-Assisted Development
+
+## 1. Why this file exists
+
+This repository was built primarily through AI-assisted development. The existing README explicitly states that the original author was not a software developer and that the implementation was produced with ChatGPT 5.2.
+
+That history is relevant to anyone taking over the project. AI made it possible to build a broad, working prototype, but the resulting code must not be assumed to have received the same design review, test coverage or security review as a conventionally maintained production application.
+
+This file explains:
+
+- how AI has been used;
+- what that means for the present codebase;
+- how future AI agents should work in the repository;
+- which decisions must remain subject to human review.
+
+It does not contain hidden prompts, model transcripts or a complete development history. Those artefacts are not present in the repository.
+
+---
+
+## 2. How AI has been used
+
+### Confirmed use
+
+The repository's README records that ChatGPT 5.2 was used to create the project. Based on that statement, AI should be treated as the primary implementation assistant for the existing code.
+
+AI has evidently been used for work including:
+
+- generating C++ integration code;
+- creating Win32 and WebView2 application structure;
+- adding platform API clients;
+- creating HTML, CSS and JavaScript control surfaces and overlays;
+- breaking parts of the original implementation into modules;
+- writing comments and diagnostics;
+- implementing JSON persistence and HTTP routes;
+- iterating on simulator and streaming features.
+
+The precise model, prompt and human review level for each individual file cannot be established from the repository alone.
+
+### Reasonable inference from the code
+
+The code contains several characteristics commonly produced by iterative, prompt-driven development:
+
+- very detailed explanatory comments in some files and little documentation in others;
+- multiple abstractions for related concerns;
+- old implementation paths remaining after newer paths were added;
+- comments and diagnostics that refer to superseded configuration mechanisms;
+- a large route file that accumulated many unrelated features;
+- partially implemented interfaces and placeholder components;
+- duplicated or unusual ownership members that no longer appear to be wired.
+
+These observations do not mean the code is unusable. They mean that the current behaviour must be traced and tested rather than inferred from filenames, comments or class names alone.
+
+---
+
+## 3. Current AI-era artefacts to understand
+
+The following examples are known at the time of this handover:
+
+### Active implementation versus remnants
+
+- The active YouTube implementation uses native C++ OAuth, channel-statistics, live-status and live-chat services.
+- `YouTubeSidecar.*` and `youtube_sidecar.py` remain in the project but were not found in the active runtime wiring.
+- `AppRuntime` has a member named `youtube` whose type is `TikTokSidecar`; it appears to be an unused remnant.
+
+An AI agent must not extend an apparently relevant class until it has traced whether that class is actually constructed, started and consumed.
+
+### Stubbed functionality
+
+`ObsWsClient` is a stub. Its `connect()` method always returns false and `set_text()` is a no-op. Although `ObsMetricsPublisher` calls it, there is no functioning OBS WebSocket update path. The operational OBS integration is currently the local browser-source overlays.
+
+An AI agent must not describe this feature as working simply because the class and worker exist.
+
+### Monolithic HTTP implementation
+
+`HttpServer.cpp` contains many route groups, external API helpers, file-persistence helpers, SimBrief polling and SimConnect exposure. This makes broad edits risky because apparently unrelated features share one translation unit.
+
+Future changes should extract one coherent route or service group at a time and preserve route behaviour during the move.
+
+### Stale names and configuration models
+
+Some diagnostics refer to credentials being read directly from `config.json`, while the current design expects OAuth application credentials through `EmbeddedOAuthConfig.local.h` and user tokens through `config.json`.
+
+AI-generated comments are documentation, not proof. Follow the actual call path.
+
+---
+
+## 4. Rules for future AI agents
+
+These rules apply to ChatGPT, Codex, Claude and any other automated coding agent used on the repository.
+
+### 4.1 Read before editing
+
+Before making changes, read at least:
+
+1. `architecture.md`;
+2. `toberemoved.md`;
+3. `README.md`;
+4. `Mode-S Client/Mode-S Client.vcxproj`;
+5. the entry point in `src/Mode-S Client.cpp`;
+6. `src/app/AppRuntime.h`;
+7. `src/app/AppBootstrap.cpp`;
+8. `src/app/AppShutdown.cpp`;
+9. every caller and consumer of the component being changed.
+
+Do not treat code search results as a substitute for reading the relevant implementation.
+
+### 4.2 Trace the active path
+
+For each proposed change, identify:
+
+- who owns the object;
+- who starts it;
+- which thread invokes it;
+- where its output is stored;
+- which API/UI/overlay consumes that output;
+- how it is stopped;
+- whether another older implementation exists.
+
+A useful change description should be able to state this path in plain language.
+
+### 4.3 Keep changes small
+
+Prefer one coherent change per pull request. Examples:
+
+- make the SimBrief ID configurable;
+- replace embedded branding with a brand configuration object;
+- extract Twitch routes from `HttpServer.cpp`;
+- implement the OBS WebSocket client;
+- remove the unused YouTube sidecar.
+
+Do not combine a takeover cleanup, large refactor, dependency upgrade and new feature into one patch.
+
+### 4.4 Do not rewrite working areas without evidence
+
+Broad AI rewrites can remove subtle platform behaviour, event normalization, rate limiting or shutdown handling. Preserve interfaces and behaviour unless the task explicitly calls for a breaking change.
+
+When refactoring:
+
+- move code before redesigning it;
+- keep endpoint paths and JSON response shapes stable;
+- retain existing failure handling until tests prove a replacement;
+- compare before/after behaviour with recorded fixtures where possible.
+
+### 4.5 Preserve runtime lifetimes
+
+Long-running services are owned by `AppRuntime`. Startup receives short-lived dependency views. Never capture those temporary wrapper objects by reference in asynchronous callbacks.
+
+Every added worker must have:
+
+- a long-lived owner;
+- a stop flag or cancellation mechanism;
+- a deterministic join/stop path;
+- an entry in `AppShutdown` where appropriate.
+
+### 4.6 Respect the loopback security boundary
+
+The local HTTP server currently binds to `127.0.0.1`. Do not change it to `0.0.0.0`, a LAN address or an internet-facing listener without implementing a security design first.
+
+Many routes can:
+
+- modify account settings;
+- start or stop platform clients;
+- update stream information;
+- manage rewards;
+- send messages;
+- invoke simulator automation.
+
+Exposing those routes would require authentication, authorization, CSRF protection, input limits, secret handling and a threat review.
+
+### 4.7 Never commit credentials
+
+Do not commit:
+
+- `config.json`;
+- `EmbeddedOAuthConfig.local.h`;
+- OAuth client secrets;
+- access or refresh tokens;
+- TikTok cookies;
+- account-specific channel IDs where they are intended to remain private;
+- OBS passwords;
+- local browser/session data;
+- copied production logs containing tokens or personal data.
+
+Use redacted fixtures or obvious placeholders in examples.
+
+Before proposing a commit, search the diff for terms such as:
+
+```text
+client_secret
+access_token
+refresh_token
+sessionid
+Authorization:
+Bearer 
+oauth:
+```
+
+### 4.8 Do not inherit the original operator's identity
+
+New work must not introduce or preserve a personal account, pilot ID, social handle, reward ID or brand string as a default.
+
+Account identifiers belong in local configuration. Brand values should be configurable or placed in one clearly documented branding module.
+
+Use `toberemoved.md` as the current audit list and update it as items are resolved.
+
+### 4.9 Be explicit about incomplete validation
+
+An AI agent must state exactly what was tested. Acceptable statements include:
+
+- project compiled in Debug x64;
+- project compiled in Release x64;
+- local `/app` and selected API routes were smoke-tested;
+- Twitch OAuth was not tested because no test account was available;
+- simulator integration was not tested because MSFS/Fenix was unavailable.
+
+Do not claim that a change is working merely because it is syntactically plausible or because a file was successfully edited.
+
+### 4.10 Update documentation with architecture changes
+
+A change must update `architecture.md` when it alters:
+
+- service ownership;
+- startup or shutdown;
+- local ports or route groups;
+- persistence locations;
+- authentication flows;
+- platform data flow;
+- thread behaviour;
+- build prerequisites;
+- the status of a stub or legacy component.
+
+Update `toberemoved.md` when a takeover item is resolved, replaced or newly discovered.
+
+---
+
+## 5. Recommended AI workflow
+
+### Step 1: Establish scope
+
+Restate the requested outcome and identify the minimum files required. Check for unrelated working-tree or branch changes before editing.
+
+### Step 2: Map the implementation
+
+Use code search to find declarations, constructors, calls, routes, configuration keys and UI consumers. Read complete files around the relevant sections.
+
+### Step 3: Identify risks
+
+Consider:
+
+- account ownership;
+- secret exposure;
+- thread lifetime;
+- shutdown hangs;
+- API rate limits;
+- platform permission scopes;
+- backward compatibility of local JSON;
+- overlay response shape;
+- build portability.
+
+### Step 4: Implement narrowly
+
+Patch only the intended behaviour. Avoid opportunistic formatting or unrelated renaming.
+
+### Step 5: Validate in layers
+
+Where the development environment permits:
+
+1. restore packages;
+2. compile Debug x64;
+3. compile Release x64;
+4. run the client with a clean test configuration;
+5. test the affected local API route;
+6. test the associated UI/overlay;
+7. test the external platform or simulator with a non-production account/session;
+8. verify clean shutdown.
+
+### Step 6: Review the diff
+
+Check for:
+
+- accidental secrets;
+- unrelated changes;
+- duplicated implementations;
+- new hardcoded account data;
+- missing error handling;
+- missing shutdown wiring;
+- stale comments and documentation.
+
+### Step 7: Publish as a reviewable change
+
+Use a dedicated branch and draft pull request. The pull request should explain:
+
+- what changed;
+- why it changed;
+- the runtime path affected;
+- what was tested;
+- what could not be tested;
+- any migration or credential action required.
+
+---
+
+## 6. Human review requirements
+
+AI should assist, not act as the final authority, for the following areas.
+
+### Authentication and account transfer
+
+A human owner must create, control and revoke Twitch, Google/YouTube and TikTok credentials. AI must not decide to transfer or retain another person's tokens.
+
+### Platform terms and policy
+
+Platform API scopes, automated chat behaviour, scraping/session-cookie use, monetization events and simulator-triggered rewards can have policy implications. A human maintainer must confirm current platform terms before deployment.
+
+### Simulator automation safety
+
+The Fenix failure feature can change the simulated aircraft state in response to public support events. A human operator must approve:
+
+- which events count as credits;
+- conversion thresholds;
+- eligible failures;
+- immediate versus armed behaviour;
+- cooldowns;
+- maximum frequency;
+- the panic-stop procedure.
+
+### Security and distribution
+
+A human reviewer must approve any change that:
+
+- exposes the HTTP server beyond loopback;
+- changes secret storage;
+- adds telemetry or remote services;
+- creates an installer or auto-updater;
+- signs and distributes binaries.
+
+### Licensing
+
+The repository currently says that licensing is not finalised. A human rights holder must select and apply a licence before a formal transfer, open-source release or third-party binary distribution.
+
+---
+
+## 7. Areas suitable for future AI-assisted improvement
+
+AI can be useful for the following, provided each change is reviewed and tested:
+
+- breaking `HttpServer.cpp` into route modules;
+- creating configuration schemas and migration helpers;
+- replacing machine-specific build paths with MSBuild properties;
+- adding unit tests for normalization, persistence and bot throttling;
+- adding recorded JSON fixtures for platform events;
+- implementing a genuine OBS WebSocket transport;
+- removing confirmed dead YouTube sidecar code;
+- consolidating branding into configuration;
+- adding secure Windows credential storage;
+- adding CI for dependency restore and compilation;
+- producing an installer and clean first-run setup flow.
+
+The preferred use of AI is incremental modernization around known behaviour, not wholesale regeneration of the application.
+
+---
+
+## 8. Definition of done for AI-generated changes
+
+An AI-assisted change is not complete until:
+
+- its active call path has been traced;
+- no personal credentials or account identifiers were introduced;
+- the implementation has an owner and shutdown path where required;
+- relevant builds/tests have been run or explicitly marked unavailable;
+- the diff contains no unrelated edits;
+- user-facing or architectural documentation is updated;
+- a human can understand the change without reading the AI conversation that produced it.

--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,459 @@
+# Mode-S Client Architecture
+
+## 1. Purpose
+
+Mode-S Client is a Windows desktop application for running a multi-platform aviation livestream. It combines:
+
+- Twitch, TikTok and YouTube chat and channel data
+- a configurable chat-command bot
+- local web pages for the desktop control surface
+- OBS browser-source overlays
+- EuroScope data ingestion
+- Microsoft Flight Simulator data through SimConnect
+- SimBrief flight-plan data
+- optional Fenix aircraft failure automation driven by support events
+
+The application is a **local control plane**, not a hosted service. The executable starts an HTTP server on the loopback interface and embeds its own web interface using WebView2. OBS normally consumes the same local server through browser sources.
+
+This document describes the code as it currently exists. It also identifies incomplete or legacy components so that their presence is not mistaken for a working feature.
+
+---
+
+## 2. System context
+
+```mermaid
+flowchart LR
+    User[Streamer / operator]
+    App[Mode-S Client\nWin32 + C++17]
+    UI[Embedded WebView2 UI]
+    HTTP[Local HTTP server\n127.0.0.1:17845]
+    OBS[OBS browser sources]
+    Twitch[Twitch APIs\nIRC / Helix / EventSub / OAuth]
+    TikTok[TikTok Live\nPython sidecar]
+    YouTube[YouTube APIs\nOAuth / Data / Live Chat]
+    EuroScope[EuroScope producer]
+    MSFS[Microsoft Flight Simulator\nSimConnect]
+    SimBrief[SimBrief]
+    Fenix[Fenix EFB local API\nlocalhost:8083]
+    Files[Local JSON files]
+
+    User --> App
+    App --> UI
+    UI <--> HTTP
+    OBS --> HTTP
+    HTTP <--> App
+    App <--> Twitch
+    App <--> TikTok
+    App <--> YouTube
+    EuroScope --> HTTP
+    App <--> MSFS
+    App --> SimBrief
+    App <--> Fenix
+    App <--> Files
+```
+
+The loopback HTTP server is the central integration surface inside the application. It serves the user interface and overlays, exposes application state as JSON, accepts local control requests, and receives EuroScope data.
+
+---
+
+## 3. Technology and build model
+
+### Native application
+
+- Windows desktop application
+- C++17
+- Win32 window and message loop
+- Visual Studio project: `Mode-S Client/Mode-S Client.vcxproj`
+- WebView2 for the embedded HTML user interface
+- `cpp-httplib` for the embedded HTTP server and some HTTPS clients
+- `nlohmann::json` for JSON parsing and serialization
+- WinHTTP for several direct HTTP integrations
+- OpenSSL support supplied through the NuGet package referenced by the project
+- SimConnect SDK for Microsoft Flight Simulator integration
+
+### Web and sidecar components
+
+- HTML, CSS and JavaScript under `Mode-S Client/assets/`
+- Python TikTok sidecar under `Mode-S Client/scripts/sidecar/`
+- static overlay pages intended for OBS browser sources
+
+### Build-time behaviour
+
+The Visual Studio project runs `tools/gen_version.ps1` before compilation to create version information. Release builds copy the sidecar directory and static assets into the output directory.
+
+The project currently contains machine-specific SimConnect SDK include and library paths. These are documented in `toberemoved.md` and must be replaced before another developer can build on a differently configured machine.
+
+NuGet package restore is required for WebView2 and OpenSSL. The SimConnect SDK must be installed separately.
+
+---
+
+## 4. Source layout
+
+```text
+Mode-S Client/
+├── src/
+│   ├── Mode-S Client.cpp          Native entry point and Win32 shell
+│   ├── AppConfig.h                Runtime configuration loading/saving
+│   ├── AppState.*                 Shared application state
+│   ├── app/                       Startup, runtime ownership and shutdown
+│   ├── bot/                       Command dispatch and persistence wiring
+│   ├── chat/                      Unified chat aggregator
+│   ├── http/                      Local HTTP server and route wiring
+│   ├── overlay/                   Overlay header persistence
+│   ├── platform/                  Platform start/stop helpers
+│   ├── runtime/                   Long-running service coordinators
+│   ├── supporter/                 Recent supporter aggregation
+│   └── ui/                        WebView, splash and native window helpers
+├── integrations/
+│   ├── euroscope/                 EuroScope JSON ingestion
+│   ├── fenixsim/                  Fenix failure API and automation
+│   ├── metar/                     AviationWeather METAR command
+│   ├── obs/                       OBS WebSocket abstraction (currently a stub)
+│   ├── simconnect/                Live MSFS aircraft data
+│   ├── tiktok/                    Sidecar process wrapper and follower service
+│   ├── twitch/                    OAuth, IRC, Helix and EventSub
+│   └── youtube/                   OAuth, stats, live status and live chat
+├── assets/
+│   ├── app/                       Embedded control surface
+│   ├── overlay/                   OBS browser-source pages
+│   └── icons/                     Application and platform artwork
+├── scripts/sidecar/               Python sidecars and bundled dependencies
+├── bot_commands.json              Default bot commands
+└── config.example.json            Example local account configuration
+```
+
+---
+
+## 5. Runtime ownership
+
+`AppRuntime` is the long-lived owner of almost all services and shared objects. A single global `AppRuntime` instance is created in `Mode-S Client.cpp` and remains alive until process exit.
+
+It owns:
+
+- `AppConfig`
+- `AppState`
+- `ChatAggregator`
+- Twitch IRC, EventSub and OAuth clients
+- YouTube OAuth and live-chat services
+- TikTok sidecar wrapper
+- the local HTTP server
+- EuroScope ingest state
+- SimBrief and SimConnect indirectly through the HTTP server
+- the Fenix failure API client and coordinator
+- the OBS client abstraction
+- worker threads and atomic lifecycle flags
+
+This central ownership is important. Asynchronous callbacks must capture the long-lived objects themselves, not temporary dependency-wrapper objects created during startup.
+
+### Startup sequence
+
+```mermaid
+sequenceDiagram
+    participant Win as Win32 entry point
+    participant Runtime as AppRuntime
+    participant Boot as AppBootstrap
+    participant Web as WebView2
+    participant HTTP as HttpServer
+    participant Services as Platform/runtime services
+
+    Win->>Win: Initialise COM and register window class
+    Win->>Web: Prepare shared WebView2 environment
+    Win->>Win: Create splash and native window
+    Win->>Runtime: Build startup dependency view
+    Runtime->>Boot: InitializeUiAndState()
+    Boot->>Boot: Load config and local JSON state
+    Boot->>Web: Create embedded control surface
+    Win->>Win: Post deferred backend-start message
+    Win->>Runtime: Build startup dependency view again
+    Runtime->>Boot: StartBackend()
+    Boot->>HTTP: Construct and start local server
+    Boot->>Services: Start Twitch, TikTok, YouTube and workers
+    Boot->>Web: Navigate to local /app page
+    Win->>Win: Hide splash and show application
+```
+
+The backend start is deferred until after native window creation. This allows the window procedure to finish before worker services and WebView navigation begin.
+
+### Shutdown sequence
+
+`AppShutdown::BeginShutdown()` is guarded by an atomic flag and can safely be called from both `WM_CLOSE` and the `WM_DESTROY` fallback path.
+
+The intended order is:
+
+1. set shared running flags to false;
+2. stop and destroy the HTTP server;
+3. join the TikTok follower, Twitch Helix and metrics threads;
+4. stop Fenix automation;
+5. stop Twitch EventSub, OAuth and IRC;
+6. stop YouTube chat and runtime services;
+7. stop TikTok;
+8. destroy the native window and leave the Win32 message loop.
+
+Any new long-running component must be added to both runtime ownership and orderly shutdown.
+
+---
+
+## 6. Shared state and data flow
+
+### `AppState`
+
+`AppState` is the shared in-memory model exposed to the web UI and overlays. Its responsibilities include:
+
+- aggregate viewer, follower and live-state metrics;
+- recent logs;
+- Twitch EventSub diagnostics and event queues;
+- TikTok and YouTube event queues;
+- unified alert history and replay;
+- EuroScope tag events;
+- platform requested-state tracking;
+- bot commands and bot safety settings;
+- bot reply events for overlays;
+- overlay title and subtitle;
+- Twitch stream-information draft data;
+- Twitch Channel Points reward actions, pending items and history.
+
+Most collections are bounded queues or snapshots protected by mutexes. State is predominantly process-local. Selected configuration is persisted to JSON files.
+
+### `ChatAggregator`
+
+All supported chat sources are converted into a common `ChatMessage` structure and inserted into `ChatAggregator`.
+
+```mermaid
+flowchart TD
+    TI[Twitch IRC / EventSub]
+    TK[TikTok sidecar]
+    YT[YouTube live chat]
+    CA[ChatAggregator]
+    Ring[Bounded recent-message ring]
+    Bot[BotCommandDispatcher]
+    API[/api/chat and overlay consumers]
+
+    TI --> CA
+    TK --> CA
+    YT --> CA
+    CA --> Ring
+    CA --> Bot
+    Ring --> API
+    Bot --> TI
+    Bot --> YT
+    Bot --> API
+```
+
+`ChatAggregator::Add()` updates the ring while holding its mutex, then invokes its subscriber outside the lock. The subscriber currently drives command handling.
+
+The bot sends native replies to Twitch and YouTube. TikTok command replies are overlay-only in the default implementation because native sending depends on a paid third-party route.
+
+---
+
+## 7. Local HTTP server
+
+The server binds to `127.0.0.1` on port `17845`. The embedded WebView navigates to:
+
+```text
+http://127.0.0.1:17845/app
+```
+
+OBS browser sources use pages under `/overlay/` on the same server.
+
+The route implementation is concentrated in `src/http/HttpServer.cpp`. Its route families include:
+
+- application logs and diagnostics;
+- aggregate metrics and EuroScope status;
+- recent chat and alert history;
+- bot command/settings management and test injection;
+- platform runtime status and start/stop control;
+- account configuration and OAuth callbacks;
+- Twitch stream information, EventSub, Channel Points and rewards;
+- YouTube live/VOD operations;
+- recent supporter aggregation;
+- SimBrief and SimConnect snapshots;
+- overlay header/configuration;
+- Fenix simulator-automation status and emergency controls;
+- static application and overlay assets.
+
+`HttpServerOptionsBuilder` keeps platform-specific callbacks out of the server constructor. It wires the server to the long-lived clients owned by `AppRuntime`.
+
+### Trust boundary
+
+The loopback-only bind is a meaningful security boundary because many routes change local state or invoke platform APIs. A future change to bind on all interfaces must not be made without adding authentication, authorization, request validation and cross-site request protections.
+
+---
+
+## 8. Platform integrations
+
+### Twitch
+
+The Twitch implementation has four main parts:
+
+- `TwitchAuth`: OAuth authorization, refresh, validation and token persistence;
+- `TwitchIrcWsClient`: chat ingestion and message sending;
+- `TwitchHelixService` / controller: followers, viewers, channel data and channel updates;
+- `TwitchEventSubWsClient`: subscriptions, events, Channel Points and diagnostics.
+
+The OAuth application client ID and secret are expected through the ignored local header `src/oauth/EmbeddedOAuthConfig.local.h`. User access and refresh tokens are stored in local `config.json`.
+
+Changing `twitch_login` can cause the Helix poller and chat/EventSub clients to be rebound to another channel. A new owner must create and authorize their own Twitch application rather than inherit the previous owner's credentials.
+
+### TikTok
+
+TikTok is implemented as a Python child process using the `TikTokLive` package. The C++ process communicates with it through newline-delimited JSON over redirected standard input/output pipes.
+
+The sidecar reads:
+
+- TikTok unique ID;
+- `sessionid` or `sessionid_ss`;
+- `tt_target_idc` where available.
+
+It emits normalized chat, follow, gift, like, share, subscription, viewer and status events. The C++ wrapper parses each JSON line and passes it into application state/chat.
+
+The sidecar and its Python dependencies must be distributed with the executable. TikTok cookies are sensitive account credentials and must not be committed or transferred without explicit authorization.
+
+### YouTube
+
+The active implementation is native C++ and consists of:
+
+- OAuth and token refresh;
+- channel-statistics polling;
+- live-status discovery;
+- live-chat ingestion and replies;
+- selected VOD/live-management routes in the HTTP server.
+
+Google OAuth client credentials are supplied through the same ignored local OAuth header mechanism. Tokens, channel ID and handle are stored locally in `config.json`.
+
+`YouTubeSidecar.*` and `youtube_sidecar.py` remain in the project, but no active runtime wiring was found during the handover audit. They should be treated as legacy until proven otherwise.
+
+---
+
+## 9. Aviation and simulator integrations
+
+### EuroScope
+
+`EuroScopeIngestService` accepts JSON generated by an external EuroScope-side producer. The payload must include `ts_ms`. The most recent payload is held in memory and merged into `/api/metrics`.
+
+Connectivity is inferred from the age of the last payload; there is no VATSIM account login in this client-side ingest service.
+
+### METAR
+
+The `!metar ICAO` bot command calls the public AviationWeather API and caches each station result for one minute. It does not use a personal API key.
+
+### SimConnect
+
+The SimConnect worker repeatedly attempts to attach to the local Microsoft Flight Simulator session. It requests:
+
+- pressure/plane altitude;
+- ground speed;
+- indicated airspeed;
+- latitude;
+- longitude.
+
+The worker stores a thread-safe snapshot consumed by HTTP routes and overlays. Build-time access to the SimConnect headers and library is required.
+
+### SimBrief
+
+The HTTP server runs a background worker that requests the latest SimBrief plan every ten minutes and reduces it to a small cache containing callsign, origin, destination, route distance and coordinates.
+
+The current pilot ID is hardcoded to the original operator's account. This is a takeover blocker and is listed in `toberemoved.md`.
+
+### Fenix failure automation
+
+The Fenix integration calls a local HTTP API at `localhost:8083` to read, arm, trigger and clear manual aircraft failures.
+
+`FenixFailureCoordinator` watches monetization/support events from Twitch, TikTok and YouTube, converts eligible events into credits, and can spend those credits on random failures. The current selection split is 60% immediate and 40% armed/delayed. Automation starts disabled and provides a panic-stop operation that disables further actions and attempts to clear active/armed failures.
+
+Failure metadata is generated and merged with the failures discovered from the local Fenix endpoint.
+
+This feature is stream-policy-specific and should be reviewed before being enabled by a new operator.
+
+---
+
+## 10. OBS integration
+
+The working OBS integration is the set of browser-source overlays served by the local HTTP server.
+
+There is also an `ObsMetricsPublisher` worker that attempts to update OBS text inputs every five seconds. However, `ObsWsClient` is currently a stub: `connect()` always returns false and `set_text()` performs no operation. The text-input publisher must therefore be considered non-functional until a real OBS WebSocket client is implemented.
+
+---
+
+## 11. Configuration and persistence
+
+### Files expected beside the executable or working directory
+
+| File | Purpose | Source controlled? |
+|---|---|---:|
+| `config.json` | Platform identities, cookies, OAuth tokens, UI settings and cached values | No |
+| `bot_commands.json` | Chat command definitions | Default file is tracked; runtime copy may change |
+| `bot_settings.json` | Rate limits, maximum reply length and silent mode | Normally local |
+| `overlay_header.json` | Overlay title/subtitle | Normally local |
+| `twitch_streaminfo.json` | Twitch stream draft and currently some YouTube VOD draft data | Normally local |
+| Fenix failure metadata JSON | Generated/edited failure policy metadata | Local/generated |
+| `EmbeddedOAuthConfig.local.h` | Twitch and Google OAuth client credentials | No |
+
+`AppConfig` searches the current working directory first and then the executable directory. This can lead to different configuration files being used depending on how the application is launched. A successor should standardize the data directory before distributing the application more widely.
+
+### Sensitive data
+
+The current design stores platform tokens and TikTok cookies in plaintext local files. They are excluded from Git but are not encrypted at rest. A production-quality handover should migrate secrets to Windows Credential Manager or another operating-system-backed secret store.
+
+---
+
+## 12. Threads and asynchronous components
+
+The application may have the following concurrent activity:
+
+- Win32/WebView UI thread;
+- embedded HTTP server thread;
+- SimBrief refresh thread;
+- SimConnect worker thread;
+- Twitch OAuth refresh worker;
+- Twitch IRC WebSocket worker;
+- Twitch EventSub WebSocket worker;
+- Twitch Helix polling thread;
+- TikTok Python child process and C++ reader thread;
+- TikTok follower polling thread;
+- YouTube OAuth/statistics/live-status/live-chat workers;
+- Fenix failure coordinator thread;
+- OBS metrics publisher thread.
+
+Rules for future changes:
+
+1. long-running objects must be owned by `AppRuntime` or another clearly longer-lived owner;
+2. callbacks must not capture temporary dependency wrappers by reference;
+3. mutable cross-thread state must remain protected by mutexes or atomics;
+4. every new thread/service must have a defined stop operation and be included in shutdown;
+5. callbacks should not perform slow work while holding `AppState` or aggregator locks.
+
+---
+
+## 13. Known incomplete or legacy areas
+
+- `ObsWsClient` is a no-op stub.
+- `YouTubeSidecar` and `youtube_sidecar.py` appear to be legacy and are not wired into the current startup path.
+- `AppRuntime` contains an additional member named `youtube` whose type is `TikTokSidecar`; it is not part of the current bootstrap dependency set and appears to be a remnant.
+- `HttpServer.cpp` is a large monolithic route implementation and contains unrelated persistence/API helpers.
+- Some comments and diagnostics describe older configuration mechanisms.
+- Some YouTube VOD draft data is stored in a file named `twitch_streaminfo.json`.
+- There is no functioning OBS WebSocket transport despite the publisher thread.
+- No automated test project or GitHub Actions workflow was identified during this documentation audit.
+- The repository currently states that its licence is not finalised. Licensing must be resolved before a formal transfer or third-party distribution.
+
+---
+
+## 14. Takeover checklist
+
+A new maintainer should complete the following before using the client with real accounts:
+
+1. Read `toberemoved.md` and remove or parameterize every original-owner dependency.
+2. Create new Twitch and Google OAuth applications and update allowed redirect URLs.
+3. Generate a new ignored `EmbeddedOAuthConfig.local.h` from a documented template.
+4. Start with a clean `config.json`; do not reuse the previous owner's tokens or TikTok cookies.
+5. Replace all RadarController/StreamingATC branding and visual assets.
+6. Replace the hardcoded SimBrief pilot ID.
+7. replace the machine-specific SimConnect SDK paths with portable project properties or environment variables.
+8. Restore NuGet packages and build Debug x64 and Release x64.
+9. Smoke-test the local UI and overlays before connecting social accounts.
+10. Test one platform at a time, then combined chat and alert handling.
+11. Keep Fenix automation disabled until its support-event policy and failure mappings have been reviewed.
+12. Revoke any credentials belonging to the previous operator.
+13. Choose and document an open-source or transfer licence before publication or redistribution.
+
+For guidance on using AI to maintain this repository, see `agents.md`.

--- a/toberemoved.md
+++ b/toberemoved.md
@@ -1,0 +1,570 @@
+# Items to Remove or Replace Before Handover
+
+## 1. Scope
+
+This is the takeover audit requested for Mode-S Client. It records:
+
+- values hardcoded to the original RadarController/StreamingATC identity;
+- external applications, tokens and account state that belong to the original operator;
+- machine-specific build settings;
+- stream-specific defaults that a successor should consciously adopt, change or remove;
+- legacy and incomplete code that should not be presented as operational.
+
+This file is intentionally an action register. Items should be checked off or removed from this document as they are resolved.
+
+No committed live OAuth secret was found during the audit. The repository deliberately excludes the local credential header and `config.json`. That does **not** remove the need to revoke the original credentials and authorize replacement accounts.
+
+---
+
+## 2. Priority 0: account ownership and credentials
+
+These items must be resolved before another person runs the application with real accounts.
+
+### 2.1 SimBrief account is hardcoded
+
+- [ ] Replace the hardcoded SimBrief pilot ID `11686`.
+
+Location:
+
+```text
+Mode-S Client/src/http/HttpServer.cpp
+```
+
+`StartSimBriefWorker()` declares the ID twice: once in the function scope and once inside the worker-thread lambda. The worker requests:
+
+```text
+www.simbrief.com/api/xml.fetcher.php?userid=11686&json=1
+```
+
+Until changed, every installation will continue to fetch the original operator's latest SimBrief plan.
+
+Recommended fix:
+
+- add `simbrief_pilot_id` to `AppConfig` and `config.example.json`;
+- do not start the worker when it is unset or invalid;
+- expose the setting through the local UI;
+- remove both hardcoded declarations;
+- avoid logging the full returned plan where it could expose personal flight data.
+
+### 2.2 Twitch developer application and user authorization
+
+- [ ] Revoke or retire the original Twitch developer application credentials.
+- [ ] Create a Twitch developer application controlled by the new maintainer.
+- [ ] Configure the replacement OAuth redirect URI used by the local callback route.
+- [ ] Create a new ignored `EmbeddedOAuthConfig.local.h` containing the replacement app credentials.
+- [ ] Delete the original local `config.json` rather than transferring its Twitch tokens.
+- [ ] Authorize the replacement Twitch account through the application.
+- [ ] Set a replacement `twitch_login`.
+
+Relevant tracked code:
+
+```text
+Mode-S Client/src/oauth/EmbeddedOAuthConfig.h
+Mode-S Client/integrations/twitch/TwitchAuth.*
+Mode-S Client/integrations/twitch/TwitchIrcWsClient.*
+Mode-S Client/integrations/twitch/TwitchHelixService.*
+Mode-S Client/integrations/twitch/TwitchEventSubWsClient.*
+Mode-S Client/src/runtime/TwitchRuntimeCoordinator.cpp
+Mode-S Client/src/http/HttpServerOptionsBuilder.cpp
+```
+
+Relevant local/ignored data:
+
+```text
+Mode-S Client/src/oauth/EmbeddedOAuthConfig.local.h
+config.json -> twitch_login
+config.json -> twitch.user_access_token
+config.json -> twitch.user_refresh_token
+```
+
+The tracked header uses macros named `RC_TWITCH_CLIENT_ID` and `RC_TWITCH_CLIENT_SECRET`. The values default to empty and the real local header is ignored. The `RC_` prefix is branding residue and should eventually be renamed to a neutral project prefix, but renaming it is secondary to replacing the credentials.
+
+The current Twitch authorization requests broad channel-management scopes, including chat, followers, subscriptions, bits, Channel Points and broadcast management. The new maintainer should review and reduce the scopes to those actually required.
+
+No hardcoded Twitch broadcaster numeric ID was found in the tracked code. The runtime resolves the configured login through Twitch APIs.
+
+### 2.3 Twitch Channel Points rewards and mappings
+
+- [ ] Remove or recreate rewards owned by the original Twitch channel.
+- [ ] Clear locally persisted reward action mappings before connecting a replacement channel.
+- [ ] Replace any reward-specific images and sounds.
+- [ ] Verify that pending/history data does not contain original channel redemption IDs.
+
+Reward IDs are channel-specific even where they are not hardcoded into source code. Runtime mappings are persisted through application state/config and should not be copied blindly to another broadcaster.
+
+The repository ignores these potentially account-specific asset directories:
+
+```text
+Mode-S Client/assets/channel-points/
+Mode-S Client/assets/sounds/
+```
+
+They are not covered by the committed-file text audit. Inspect and remove any local copies before handing over a build directory or development machine.
+
+### 2.4 Google/YouTube developer application and channel authorization
+
+- [ ] Revoke or retire the original Google OAuth client.
+- [ ] Create a Google Cloud project/OAuth client controlled by the new maintainer.
+- [ ] Configure the local YouTube OAuth redirect URI.
+- [ ] populate the ignored local OAuth header with the replacement client ID and secret.
+- [ ] Delete the original YouTube tokens/channel state from local `config.json`.
+- [ ] Authorize the replacement YouTube channel.
+- [ ] Set a replacement `youtube_handle`.
+
+Relevant tracked code:
+
+```text
+Mode-S Client/src/oauth/EmbeddedOAuthConfig.h
+Mode-S Client/integrations/youtube/YouTubeAuth.*
+Mode-S Client/integrations/youtube/YouTubeChannelStatsService.*
+Mode-S Client/integrations/youtube/YouTubeLiveStatusService.*
+Mode-S Client/integrations/youtube/YouTubeLiveChatService.*
+Mode-S Client/src/runtime/YouTubeRuntimeCoordinator.cpp
+Mode-S Client/src/http/HttpServerOptionsBuilder.cpp
+Mode-S Client/src/http/HttpServer.cpp
+```
+
+Relevant local/ignored data:
+
+```text
+Mode-S Client/src/oauth/EmbeddedOAuthConfig.local.h
+config.json -> youtube.access_token
+config.json -> youtube.refresh_token
+config.json -> youtube.channel_id
+config.json -> youtube.expires_at_unix
+config.json -> youtube.scope
+config.json -> youtube_handle
+```
+
+The tracked macros `RC_YOUTUBE_CLIENT_ID` and `RC_YOUTUBE_CLIENT_SECRET` should eventually receive neutral names.
+
+### 2.5 TikTok account and session cookies
+
+- [ ] Remove the original TikTok unique ID from local configuration.
+- [ ] Remove the original `sessionid`, `sessionid_ss` and `tt_target_idc` values.
+- [ ] Connect only a replacement account that the new maintainer is authorized to use.
+- [ ] Review the current TikTokLive/session-cookie approach against current TikTok and library requirements.
+
+Relevant tracked code:
+
+```text
+Mode-S Client/scripts/sidecar/tiktok_sidecar.py
+Mode-S Client/integrations/tiktok/TikTokSidecar.*
+Mode-S Client/integrations/tiktok/TikTokFollowersService.*
+Mode-S Client/src/runtime/TikTokRuntimeCoordinator.cpp
+```
+
+Relevant local/ignored data:
+
+```text
+config.json -> tiktok_unique_id
+config.json -> tiktok_sessionid
+config.json -> tiktok_sessionid_ss
+config.json -> tiktok_tt_target_idc
+```
+
+TikTok cookies are credentials. Do not transfer them to a successor or include them in a packaged application.
+
+### 2.6 Local operational state
+
+- [ ] Do not hand over the original runtime data files without reviewing and sanitizing them.
+
+Potential local state includes:
+
+```text
+config.json
+bot_commands.json
+bot_settings.json
+overlay_header.json
+twitch_streaminfo.json
+Fenix failure metadata JSON
+generated logs and diagnostics
+WebView2 profile/cache data
+```
+
+The source-controlled `bot_commands.json` is a default file and is covered separately below. Locally modified copies may contain URLs, names or policies not present in Git.
+
+---
+
+## 3. Priority 1: hardcoded RadarController and StreamingATC identity
+
+### 3.1 Native application identity
+
+- [ ] Replace the hardcoded application display name:
+
+```text
+Mode-S Client/src/Mode-S Client.cpp
+```
+
+Current value:
+
+```text
+StreamingATC.Live Mode-S Client
+```
+
+This value is used for the splash, window title and visible application identity.
+
+- [ ] Review the native window class name `StreamHubWindow`. It is not personally identifying, but it reflects an older product name and may be renamed during a wider branding cleanup.
+
+### 3.2 Bot identity and default content
+
+- [ ] Make the synthetic bot display name configurable.
+
+Location:
+
+```text
+Mode-S Client/src/bot/BotCommandDispatcher.cpp
+```
+
+Current value:
+
+```text
+StreamingATC.Bot
+```
+
+It is used both to ignore the application's own messages and to label synthetic bot messages. This is functional coupling, not merely cosmetic text. A replacement must use the same configured identity consistently for loop prevention and overlay attribution.
+
+- [ ] Replace the default `about` response in:
+
+```text
+Mode-S Client/bot_commands.json
+```
+
+Current response:
+
+```text
+StreamingATC.Live Mode-S Client
+```
+
+- [ ] Review every locally edited bot response for original Discord links, social handles, schedules, policies and names.
+
+- [ ] Replace the example channel in the comment in:
+
+```text
+Mode-S Client/src/bot/BotReplyRouter.h
+```
+
+The `radarcontroller` value there is documentation-only, but it should not remain in a neutral handover.
+
+### 3.3 Embedded control-surface pages
+
+Explicit RadarController references were found in the following application assets:
+
+- [ ] `Mode-S Client/assets/app/index.html`
+- [ ] `Mode-S Client/assets/app/settings.html`
+- [ ] `Mode-S Client/assets/app/accounts.html`
+- [ ] `Mode-S Client/assets/app/bot.html`
+- [ ] `Mode-S Client/assets/app/channel_points.js`
+- [ ] `Mode-S Client/assets/app/diagnostics.html`
+- [ ] `Mode-S Client/assets/app/overlay_title.html`
+- [ ] `Mode-S Client/assets/app/stream_details.html`
+- [ ] `Mode-S Client/assets/app/tiktok_cookies.html`
+- [ ] `Mode-S Client/assets/app/twitch_rewards.html`
+- [ ] `Mode-S Client/assets/app/twitch_stream.html`
+- [ ] `Mode-S Client/assets/app/splash/index.html`
+
+Examples include page titles, logo alternative text, visible brand names and debug/test data. `channel_points.js`, for example, injects `RadarController` as the user in its manual debug event.
+
+The pages should use one configurable or generated brand source rather than repeating product identity in each file.
+
+### 3.4 Overlay pages and stream-specific templates
+
+Explicit RadarController/StreamingATC references were found in:
+
+- [ ] `Mode-S Client/assets/overlay/landscape/26_starting.html`
+- [ ] `Mode-S Client/assets/overlay/landscape/26_post_stream.html`
+- [ ] `Mode-S Client/assets/overlay/landscape/26_footer_blighty.html`
+- [ ] `Mode-S Client/assets/overlay/landscape/26_webcam.html`
+- [ ] `Mode-S Client/assets/overlay/portrait/26_starting.html`
+- [ ] `Mode-S Client/assets/overlay/portrait/26_post_stream.html`
+- [ ] `Mode-S Client/assets/overlay/landscape/channel_points.html`
+- [ ] `Mode-S Client/assets/overlay/portrait/channel_points_portrait.html`
+- [ ] `Mode-S Client/assets/overlay/channel_points.js`
+
+Known content includes:
+
+- `@radarcontroller`;
+- `twitch.tv/radarcontroller`;
+- StreamingATC.Live branding;
+- RadarController names and logos;
+- Blighty-specific naming in `26_footer_blighty.html`.
+
+The `26_*` naming and layout set appear to be specific to the original 2026 stream package. A successor may keep the layout, but it should be renamed and reviewed as a complete visual package rather than performing text replacement only.
+
+### 3.5 Icons, logos and compiled resources
+
+- [ ] Replace `/assets/icons/RClogo.svg` wherever used by the embedded UI.
+- [ ] Replace `Mode-S Client/assets/icons/radarcontrollermodesclient.ico`.
+- [ ] Update the icon reference in `Mode-S Client/Mode-S Client.vcxproj`.
+- [ ] Update corresponding entries in `Mode-S Client/Mode-S Client.vcxproj.filters`.
+- [ ] Review `Mode-S Client/ui/Mode-S Client.rc` and resource headers for names or assets tied to the original brand.
+- [ ] Visually inspect every binary image in `assets/icons/` and the overlay folders. Text search cannot detect words baked into PNG, JPG, ICO or other binary assets.
+
+### 3.6 Splash implementation
+
+- [ ] Review branding in:
+
+```text
+Mode-S Client/src/ui/SplashScreen.cpp
+Mode-S Client/assets/app/splash/index.html
+```
+
+The native code receives the product name from `Mode-S Client.cpp`, while the HTML splash also contains StreamingATC branding. Both must be updated together.
+
+### 3.7 README and repository metadata
+
+- [ ] Rewrite `README.md` for a neutral project or the successor's identity.
+- [ ] Remove the RadarController biography and claims about the wider StreamingATC.Live ecosystem where they are no longer applicable.
+- [ ] Update screenshots, links, contribution text and project status.
+- [ ] Resolve the licence. The current README says the licence is to be finalised and that all rights are reserved.
+- [ ] Review the GitHub repository name, description, topics, social preview and owner after the code transfer decision is made.
+
+A code handover and a legal right to redistribute are separate matters. A clear licence or written transfer arrangement is required.
+
+---
+
+## 4. Priority 1: build and machine-specific dependencies
+
+### 4.1 Hardcoded SimConnect SDK drive paths
+
+- [ ] Remove the original development-machine paths from:
+
+```text
+Mode-S Client/Mode-S Client.vcxproj
+```
+
+Current include path in x64 configurations:
+
+```text
+G:\MSFS 2024 SDK\SimConnect SDK\include
+```
+
+Current library path in x64 configurations:
+
+```text
+G:\MSFS 2024 SDK\SimConnect SDK\lib
+```
+
+Recommended replacement:
+
+- define an MSBuild property such as `$(SIMCONNECT_SDK)`;
+- read it from an untracked `.props` file or environment variable;
+- provide a documented example property sheet;
+- fail with a clear build message when the SDK is unavailable;
+- verify Debug x64 and Release x64 on a clean machine.
+
+### 4.2 Python/TikTok packaging
+
+- [ ] Confirm how Python is supplied to the replacement installation.
+- [ ] Confirm that the required `TikTokLive` dependencies are included and licensed for distribution.
+- [ ] Remove cached packages, cookies and local interpreter paths from any handover archive.
+
+The Visual Studio post-build copies the sidecar directory, but the application still needs a usable Python executable and compatible package set.
+
+### 4.3 Version-generation tooling
+
+- [ ] Verify that `tools/gen_version.ps1` is present in a fresh clone and remains tracked despite the broad `tools/` ignore rule.
+- [ ] Document PowerShell execution requirements for a clean build.
+
+---
+
+## 5. Priority 2: stream-specific behaviour to review
+
+These items are not necessarily wrong, but they reflect the original stream and should not silently become defaults for another operator.
+
+### 5.1 OBS text input names
+
+- [ ] Review these hardcoded OBS input names in `src/runtime/ObsMetricsPublisher.cpp`:
+
+```text
+TOTAL_VIEWER_COUNT
+TOTAL_FOLLOWER_COUNT
+```
+
+They are tied to a particular OBS scene collection naming convention. More importantly, the current `ObsWsClient` is a no-op stub, so changing the names alone will not make the feature work.
+
+Recommended outcome: either remove the publisher until implemented or create configurable OBS connection/input settings with a real WebSocket transport.
+
+### 5.2 Fenix monetization-to-failure policy
+
+- [ ] Review which Twitch, TikTok and YouTube events create failure credits.
+- [ ] Review bits, gift and membership/subscription conversion thresholds.
+- [ ] Review eligible failures, weights, cooldowns and per-session limits.
+- [ ] Review the hardcoded 60% immediate / 40% armed selection split.
+- [ ] Keep automation disabled by default until the successor approves the policy.
+- [ ] Remove original failure metadata and regenerate it against the successor's Fenix installation.
+
+This feature embodies stream rules, not generic application infrastructure.
+
+### 5.3 Overlay and UI timing/style defaults
+
+- [ ] Review Channel Points polling, queue, hold and animation timings.
+- [ ] Review overlay dimensions, fixed layout assumptions and typography.
+- [ ] Review the default Inter font and external Google Fonts request.
+- [ ] Replace original headers, titles, callsign examples and social prompts.
+
+### 5.4 Default bot commands
+
+- [ ] Decide whether `!help`, `!about`, `!discord` and `!bacon` belong in a neutral default installation.
+- [ ] Add `!metar` to the documented command list if the feature is retained.
+- [ ] Replace the placeholder Discord response with either configuration or no default command.
+
+### 5.5 Local port and paths
+
+The loopback port `17845` is hardcoded in multiple places. It is not RadarController-specific, but a distributable application should ideally make it configurable from one source. If changed, update:
+
+- native WebView URL;
+- HTTP server options;
+- logs and documentation;
+- OBS browser-source instructions;
+- OAuth redirect URIs.
+
+Do not expose the listener beyond loopback without adding authentication and a security design.
+
+---
+
+## 6. Priority 2: legacy, misleading or incomplete components
+
+### 6.1 Unused YouTube sidecar path
+
+- [ ] Confirm and then remove or document:
+
+```text
+Mode-S Client/integrations/youtube/YouTubeSidecar.h
+Mode-S Client/integrations/youtube/YouTubeSidecar.cpp
+Mode-S Client/scripts/sidecar/youtube_sidecar.py
+```
+
+The files are included in the project/package, but no active startup or consumer reference was found. The active YouTube implementation is native C++.
+
+### 6.2 Suspicious `AppRuntime::youtube` member
+
+- [ ] Confirm and remove or rename the following member in `src/app/AppRuntime.h`:
+
+```cpp
+TikTokSidecar youtube;
+```
+
+It is not included in the current bootstrap dependency object and appears to be a remnant of the older sidecar path.
+
+### 6.3 OBS WebSocket stub
+
+- [ ] Do not advertise direct OBS text-input updates as working.
+- [ ] Either implement `ObsWsClient` or remove the no-op publisher path.
+
+Current behaviour:
+
+```text
+ObsWsClient::connect() -> always false
+ObsWsClient::set_text() -> no operation
+```
+
+OBS browser-source overlays remain functional independently of this stub.
+
+### 6.4 Monolithic HTTP server and stale storage names
+
+- [ ] Extract route groups from `HttpServer.cpp` incrementally.
+- [ ] Move SimBrief polling and related external API logic into a dedicated service.
+- [ ] Rename or migrate `twitch_streaminfo.json`, which currently stores some YouTube VOD draft data.
+- [ ] Correct diagnostics that still describe obsolete credential locations.
+
+These are maintainability items, not immediate account-transfer blockers.
+
+---
+
+## 7. External services that are not tied to the original account
+
+The audit did not find original-owner credentials or identifiers in these integrations:
+
+| Integration | Current dependency | Takeover assessment |
+|---|---|---|
+| Local HTTP/WebView | `127.0.0.1:17845` | Generic local infrastructure |
+| EuroScope ingest | Local JSON producer with `ts_ms` | No VATSIM account authentication found |
+| AviationWeather METAR | Public `aviationweather.gov` endpoint | No personal API key found |
+| SimConnect | Local MSFS connection | Machine/SDK dependent, not account dependent |
+| Fenix EFB API | `localhost:8083` | Local simulator dependency, not RadarController account dependent |
+| WebView2 | Microsoft runtime/NuGet package | Generic dependency |
+| OpenSSL/cpp-httplib | Build/runtime libraries | Generic dependency |
+
+No VATSIM OAuth token, VATSIM account ID or direct VATSIM API integration was found in the inspected code. EuroScope data is accepted from a local producer without authenticating to VATSIM.
+
+Twitch, TikTok and YouTube integration code is reusable, but all application registrations, channel identities, user tokens, cookies, reward IDs and local state must belong to the replacement operator.
+
+---
+
+## 8. Search inventory used for the audit
+
+The following searches should return no unintended original-owner references after cleanup:
+
+```powershell
+git grep -n -i "radarcontroller"
+git grep -n -i "streamingatc"
+git grep -n -i "streamingatc.live"
+git grep -n -i "@radarcontroller"
+git grep -n -i "twitch.tv/radarcontroller"
+git grep -n "11686"
+git grep -n "G:\\MSFS 2024 SDK"
+git grep -n -i "RClogo"
+git grep -n -i "radarcontrollermodesclient"
+git grep -n "RC_TWITCH"
+git grep -n "RC_YOUTUBE"
+git grep -n "StreamingATC.Bot"
+```
+
+Also search for likely secret and identity fields:
+
+```powershell
+git grep -n -i "client_secret"
+git grep -n -i "access_token"
+git grep -n -i "refresh_token"
+git grep -n -i "sessionid"
+git grep -n -i "channel_id"
+git grep -n -i "broadcaster_user_id"
+git grep -n -i "reward_id"
+```
+
+Expected code references to field names are not secrets. Inspect the actual values and the Git history before deciding that a result is safe.
+
+Text search is insufficient for:
+
+- binary icons and images;
+- audio files;
+- ignored local asset directories;
+- build output;
+- WebView profile data;
+- deleted secrets retained in Git history;
+- repository settings and release attachments.
+
+A final handover must include a visual asset review and a secret-history scan.
+
+---
+
+## 9. Recommended removal order
+
+1. **Revoke credentials first.** Revoke original Twitch/Google tokens and remove TikTok cookies from local machines.
+2. **Start from clean local state.** Do not transfer the original `config.json`, WebView profile or runtime JSON files.
+3. **Parameterize account values.** Fix the SimBrief ID and any discovered reward/account IDs.
+4. **Make the build portable.** Remove the `G:` SimConnect paths and document prerequisites.
+5. **Centralize product identity.** Introduce one neutral brand configuration/source.
+6. **Replace UI, overlays and binary assets.** Include social URLs and debug fixtures.
+7. **Remove confirmed dead paths and label stubs accurately.** Begin with the YouTube sidecar and OBS client after verification.
+8. **Resolve licensing and repository ownership.** Do this before third-party distribution.
+9. **Run all text and secret searches again.** Review the complete diff and Git history.
+10. **Build and smoke-test with replacement accounts.** Test one platform at a time and keep Fenix automation disabled initially.
+
+---
+
+## 10. Completion criteria
+
+The takeover cleanup is complete when:
+
+- no original account credential remains active;
+- no hardcoded original account ID controls runtime data;
+- a clean clone can build without the original machine's drive layout;
+- the application can start with an empty configuration;
+- a successor can register and authorize their own platform applications;
+- UI, overlays, icons, bot identity and documentation contain no unintended original branding;
+- account-specific reward and stream policy data has been cleared or consciously recreated;
+- incomplete features are removed, implemented or clearly labelled;
+- the repository has a clear licence and transfer position;
+- the searches in this document have been reviewed with no unexplained results.


### PR DESCRIPTION
## Summary

Adds the requested handover documentation for Mode-S Client:

- `architecture.md` explains the application structure, runtime ownership, startup/shutdown, platform and simulator integrations, local HTTP/API model, configuration, threading, build prerequisites and known incomplete areas.
- `agents.md` records how AI-assisted development has been used and establishes working rules for future coding agents and human reviewers.
- `toberemoved.md` provides a prioritized audit of RadarController/StreamingATC branding, account-owned APIs and credentials, hardcoded SimBrief data, machine-specific build paths, local account state, stream-specific policies and legacy/stub components.

## Important audit findings

- SimBrief pilot ID `11686` is hardcoded twice in `HttpServer.cpp`.
- Twitch and YouTube application credentials are intentionally local/ignored, but replacement developer applications and fresh user authorization are required for takeover.
- TikTok identity and session cookies are local account credentials and must not be transferred.
- x64 project settings contain machine-specific `G:\MSFS 2024 SDK\...` include/library paths.
- Branding remains across the native title, bot identity, UI pages, splash, overlays, icons and default command data.
- `ObsWsClient` is currently a no-op stub; browser-source overlays are the working OBS path.
- the old YouTube sidecar appears to remain in the project without active runtime wiring.
- no VATSIM account/OAuth dependency was identified in the inspected client code; EuroScope ingest is local JSON input.

## Validation

- Compared the branch against `master`: only the three requested documentation files are added.
- Re-fetched all three files from the branch after commit.
- No build was run because this is a documentation-only change and no source/build files were modified.